### PR TITLE
ltp/kernel: add compat implementation for compiling ltp kernel cases

### DIFF
--- a/nuttx/asm/posix_types.h
+++ b/nuttx/asm/posix_types.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2024 Xiaomi Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* asm/posix_types.h */
+
+#ifndef _ASM_POSIX_TYPES_H
+#define _ASM_POSIX_TYPES_H
+
+/* This is just a placeholder to simplify cross-compiling the LTP Linux Kernel cases */
+
+#endif /* _ASM_POSIX_TYPES_H */

--- a/nuttx/asm/types.h
+++ b/nuttx/asm/types.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2024 Xiaomi Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* asm/types.h */
+
+#ifndef _ASM_TYPES_H
+#define _ASM_TYPES_H
+
+#include <sys/types.h>
+
+#endif /* _ASM_TYPES_H */

--- a/nuttx/dummy.c
+++ b/nuttx/dummy.c
@@ -1,0 +1,125 @@
+/*
+ * Copyright (C) 2024 Xiaomi Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <nuttx/config.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <string.h>
+#include <mntent.h>
+
+/* the following implementation build when CONFIG_SYSTEM_POPEN option is disabled.*/
+
+#ifndef CONFIG_SYSTEM_POPEN
+
+FILE *popen(const char *command, const char *mode)
+{
+  return NULL;
+}
+
+int pclose(FILE *stream)
+{
+  return OK;
+}
+#endif
+
+/* the following empty implementation using to compile the LTP Kernel case on nuttx */
+int chroot(const char *path)
+{
+  return -1;
+}
+
+int setpgid(pid_t pid, pid_t pgid)
+{
+  return -1;
+}
+
+FILE *setmntent(const char *filep, const char *type)
+{
+  return NULL;
+}
+
+struct mntent *getmntent(FILE *filep)
+{
+  return NULL;
+}
+
+struct mntent *getmntent_r(FILE *, struct mntent *, char *, int)
+{
+  return NULL;
+}
+
+int endmntent(FILE *filep)
+{
+  return -1;
+}
+
+char *hasmntopt(const struct mntent *mnt, const char *opt)
+{
+  return NULL;
+}
+
+/* the following are dummy implementation using to compile fsgid related cased on nuttx */
+
+int setfsgid(uid_t fsgid)
+{
+  return -1;
+}
+
+int setfsuid(uid_t fsuid)
+{
+  return -1;
+}
+
+/* the following syscalls are needed by:
+ * lib/tst_safe_macros.c
+ * lib/safe_macros.c
+ * lib/parse_opts.c
+ */
+int mincore(void *addr, size_t length, unsigned char *vec)
+{
+  return -1;
+}
+
+pid_t setsid(void)
+{
+  return -1;
+}
+
+int brk(void *addr)
+{
+  return -1;
+}
+
+#ifndef CONFIG_BUILD_KERNEL
+
+void *sbrk(intptr_t increment)
+{
+  return NULL;
+}
+
+#endif
+
+int getresuid(uid_t *ruid, uid_t *euid, uid_t *suid)
+{
+  return -1;
+}
+
+int getresgid(gid_t *rgid, gid_t *egid, gid_t *sgid)
+{
+  return -1;
+}

--- a/nuttx/features.h
+++ b/nuttx/features.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2024 Xiaomi Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* features.h */
+
+#ifndef _FEATURES_H
+#define _FEATURES_H
+
+/* This is just a placeholder to simplify cross-compiling the LTP Linux Kernel cases */
+
+#endif /* _FEATURES_H */

--- a/nuttx/lapi/posix_clocks.h
+++ b/nuttx/lapi/posix_clocks.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2024 Xiaomi Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* posix_clocks.h */
+
+#ifndef _LAPI_POSIX_CLOCKS_H__
+#define _LAPI_POSIX_CLOCKS_H__
+
+#include <time.h>
+
+#define MAX_CLOCKS 16
+
+#define CLOCK_MONOTONIC_RAW 5
+
+#define CLOCK_REALTIME_COARSE 6
+
+#define CLOCK_MONOTONIC_COARSE 7
+
+#define CLOCK_REALTIME_ALARM 8
+
+#define CLOCK_BOOTTIME_ALARM 9
+
+#define CLOCK_TAI 11
+
+#endif /* _LAPI_POSIX_CLOCKS_H__ */

--- a/nuttx/libaio.h
+++ b/nuttx/libaio.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2024 Xiaomi Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* libaio.h */
+
+#ifndef _LIBAIO_H
+#define _LIBAIO_H
+
+/* This is just a placeholder to simplify cross-compiling the LTP Linux Kernel cases */
+
+#endif /* _LIBAIO_H */

--- a/nuttx/linux/errno.h
+++ b/nuttx/linux/errno.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2024 Xiaomi Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* linux/errno.h */
+
+#ifndef _LINUX_ERRNO_H
+#define _LINUX_ERRNO_H
+
+#include <errno.h>
+
+#endif /* _LINUX_ERRNO_H */

--- a/nuttx/linux/fs.h
+++ b/nuttx/linux/fs.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2024 Xiaomi Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* linux/fs.h */
+
+#ifndef _LINUX_FS_H
+#define _LINUX_FS_H
+
+#include <nuttx/fs/fs.h>
+
+#endif /* _LINUX_FS_H */

--- a/nuttx/linux/futex.h
+++ b/nuttx/linux/futex.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2024 Xiaomi Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* linux/futex.h */
+
+#ifndef _LINUX_FUTEX_H
+#define _LINUX_FUTEX_H
+
+#define FUTEX_WAIT  1
+#define FUTEX_WAKE  2
+
+#endif /* _LINUX_FUTEX_H */

--- a/nuttx/linux/if_tun.h
+++ b/nuttx/linux/if_tun.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2024 Xiaomi Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* linux/if_tun.h */
+
+#ifndef _LINUX_IF_TUN_H
+#define _LINUX_IF_TUN_H
+
+/* This is just a placeholder to simplify cross-compiling the LTP Linux Kernel cases */
+
+#endif /* _LINUX_IF_TUN_H */

--- a/nuttx/linux/kernel.h
+++ b/nuttx/linux/kernel.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2024 Xiaomi Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* linux/kernel.h */
+
+#ifndef _LINUX_KERNEL_H
+#define _LINUX_KERNEL_H
+
+#include <sys/sysmacros.h>
+
+#endif /* _LINUX_KERNEL_H */

--- a/nuttx/linux/limits.h
+++ b/nuttx/linux/limits.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2024 Xiaomi Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* linux/limits.h */
+
+#ifndef _LINUX_LIMITS_H
+#define _LINUX_LIMITS_H
+
+#include <limits.h>
+
+#endif /* _LINUX_LIMITS_H */

--- a/nuttx/linux/loop.h
+++ b/nuttx/linux/loop.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2024 Xiaomi Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* linux/loop.h */
+
+#ifndef _LINUX_LOOP_H
+#define _LINUX_LOOP_H
+
+#include <nuttx/fs/loop.h>
+
+#endif /* _LINUX_LOOP_H */

--- a/nuttx/linux/mman.h
+++ b/nuttx/linux/mman.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2024 Xiaomi Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* linux/mman.h */
+
+#ifndef _LINUX_MMAN_H
+#define _LINUX_MMAN_H
+
+#include <sys/mman.h>
+
+#endif /* _LINUX_MMAN_H */

--- a/nuttx/linux/net.h
+++ b/nuttx/linux/net.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2024 Xiaomi Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* linux/net.h */
+
+#ifndef _LINUX_NET_H
+#define _LINUX_NET_H
+
+#include <nuttx/net/net.h>
+
+#endif /* _LINUX_NET_H */

--- a/nuttx/linux/random.h
+++ b/nuttx/linux/random.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2024 Xiaomi Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* linux/random.h */
+
+#ifndef _LINUX_RANDOM_H
+#define _LINUX_RANDOM_H
+
+#include <sys/random.h>
+
+#endif /* _LINUX_RANDOM_H */

--- a/nuttx/linux/rtc.h
+++ b/nuttx/linux/rtc.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2024 Xiaomi Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* linux/rtc.h */
+
+#ifndef _LINUX_RTC_H
+#define _LINUX_RTC_H
+
+#include <nuttx/timers/rtc.h>
+
+#endif /* _LINUX_RTC_H */

--- a/nuttx/linux/types.h
+++ b/nuttx/linux/types.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2024 Xiaomi Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* linux/types.h */
+
+#ifndef _LINUX_TYPES_H
+#define _LINUX_TYPES_H
+
+/* This is just a placeholder to simplify cross-compiling the LTP Linux Kernel cases */
+
+#endif /* _LINUX_TYPES_H */

--- a/nuttx/linux/unistd.h
+++ b/nuttx/linux/unistd.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2024 Xiaomi Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* linux/unistd.h */
+
+#ifndef _LINUX_UNISTD_H
+#define _LINUX_UNISTD_H
+
+#include <unistd.h>
+
+#endif /* _LINUX_UNISTD_H */

--- a/nuttx/mntent.h
+++ b/nuttx/mntent.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2024 Xiaomi Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* mntent.h */
+
+#ifndef _MNTENT_H
+#define _MNTENT_H
+
+#include <stdio.h>
+#include <unistd.h>
+
+struct mntent
+{
+  char *mnt_fsname;
+  char *mnt_dir;
+  char *mnt_type;
+  char *mnt_opts;
+  int mnt_freq;
+  int mnt_passno;
+};
+
+#endif /* _MNTENT_H */

--- a/nuttx/sys/fsuid.h
+++ b/nuttx/sys/fsuid.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2024 Xiaomi Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* sys/fsuid.h */
+
+#ifndef _SYS_FSUID_H
+#define _SYS_FSUID_H
+
+/* This is just a placeholder to simplify cross-compiling the LTP Linux Kernel cases */
+
+#endif /* _SYS_FSUID_H */

--- a/nuttx/sys/personality.h
+++ b/nuttx/sys/personality.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2024 Xiaomi Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* sys/personality.h */
+
+#ifndef _SYS_PERSONALITY_H
+#define _SYS_PERSONALITY_H
+
+/* This is just a placeholder to simplify cross-compiling the LTP Linux Kernel cases */
+
+#endif /* _SYS_PERSONALITY_H */

--- a/nuttx/sys/ptrace.h
+++ b/nuttx/sys/ptrace.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2024 Xiaomi Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* sys/ptrace.h */
+
+#ifndef _SYS_PTRACE_H
+#define _SYS_PTRACE_H
+
+/* This is just a placeholder to simplify cross-compiling the LTP Linux Kernel cases */
+
+#endif /* _SYS_PTRACE_H */

--- a/nuttx/sys/quota.h
+++ b/nuttx/sys/quota.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2024 Xiaomi Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* sys/quota.h */
+
+#ifndef _SYS_QUOTA_H
+#define _SYS_QUOTA_H
+
+/* This is just a placeholder to simplify cross-compiling the LTP Linux Kernel cases */
+
+#endif /* _SYS_QUOTA_H */

--- a/nuttx/sys/timex.h
+++ b/nuttx/sys/timex.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2024 Xiaomi Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* sys/timex.h */
+
+#ifndef _SYS_TIMEX_H
+#define _SYS_TIMEX_H
+
+/* This is just a placeholder to simplify cross-compiling the LTP Linux Kernel cases */
+
+#endif /* _SYS_TIMEX_H */

--- a/nuttx/sys/ttydefaults.h
+++ b/nuttx/sys/ttydefaults.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2024 Xiaomi Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* sys/ttydefaults.h */
+
+#ifndef _SYS_TTYDEFAULTS_H
+#define _SYS_TTYDEFAULTS_H
+
+/* This is just a placeholder to simplify cross-compiling the LTP Linux Kernel cases */
+
+#endif /* _SYS_TTYDEFAULTS_H */

--- a/nuttx/sys/user.h
+++ b/nuttx/sys/user.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2024 Xiaomi Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* sys/user.h */
+
+#ifndef _SYS_USER_H
+#define _SYS_USER_H
+
+/* This is just a placeholder to simplify cross-compiling the LTP Linux Kernel cases */
+
+#endif /* _SYS_USER_H */

--- a/nuttx/sys/xattr.h
+++ b/nuttx/sys/xattr.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2024 Xiaomi Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* sys/xattr.h */
+
+#ifndef _SYS_XATTR_H
+#define _SYS_XATTR_H
+
+/* This is just a placeholder to simplify cross-compiling the LTP Linux Kernel cases */
+
+#endif /* _SYS_XATTR_H */

--- a/nuttx/ulimit.h
+++ b/nuttx/ulimit.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2024 Xiaomi Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* ulimit.h */
+
+#ifndef _ULIMIT_H
+#define _ULIMIT_H
+
+/* This is just a placeholder to simplify cross-compiling the LTP Linux Kernel cases */
+
+#endif /* _ULIMIT_H */

--- a/nuttx/values.h
+++ b/nuttx/values.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2024 Xiaomi Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* values.h */
+
+#ifndef _VALUES_H
+#define _VALUES_H
+
+/* This is just a placeholder to simplify cross-compiling the LTP Linux Kernel cases */
+
+#endif /* _VALUES_H */


### PR DESCRIPTION
add compat implementation for vela system to make the linux testcases build work on vela