### PR TITLE
ltp/kernel: fix the multiple defintion link error

### DIFF
--- a/include/lapi/fsmount.h
+++ b/include/lapi/fsmount.h
@@ -16,14 +16,14 @@
 #include "lapi/syscalls.h"
 
 #ifndef HAVE_FSOPEN
-int fsopen(const char *fsname, unsigned int flags)
+static int fsopen(const char *fsname, unsigned int flags)
 {
 	return tst_syscall(__NR_fsopen, fsname, flags);
 }
 #endif /* HAVE_FSOPEN */
 
 #ifndef HAVE_FSCONFIG
-int fsconfig(int fd, unsigned int cmd, const char *key,
+static int fsconfig(int fd, unsigned int cmd, const char *key,
 	     const void *value, int aux)
 {
 	return tst_syscall(__NR_fsconfig, fd, cmd, key, value, aux);
@@ -31,21 +31,21 @@ int fsconfig(int fd, unsigned int cmd, const char *key,
 #endif /* HAVE_FSCONFIG */
 
 #ifndef HAVE_FSMOUNT
-int fsmount(int fd, unsigned int flags, unsigned int mount_attrs)
+static int fsmount(int fd, unsigned int flags, unsigned int mount_attrs)
 {
 	return tst_syscall(__NR_fsmount, fd, flags, mount_attrs);
 }
 #endif /* HAVE_FSMOUNT */
 
 #ifndef HAVE_FSPICK
-int fspick(int dirfd, const char *pathname, unsigned int flags)
+static int fspick(int dirfd, const char *pathname, unsigned int flags)
 {
 	return tst_syscall(__NR_fspick, dirfd, pathname, flags);
 }
 #endif /* HAVE_FSPICK */
 
 #ifndef HAVE_MOVE_MOUNT
-int move_mount(int from_dirfd, const char *from_pathname, int to_dirfd,
+static int move_mount(int from_dirfd, const char *from_pathname, int to_dirfd,
 	       const char *to_pathname, unsigned int flags)
 {
 	return tst_syscall(__NR_move_mount, from_dirfd, from_pathname, to_dirfd,
@@ -54,7 +54,7 @@ int move_mount(int from_dirfd, const char *from_pathname, int to_dirfd,
 #endif /* HAVE_MOVE_MOUNT */
 
 #ifndef HAVE_OPEN_TREE
-int open_tree(int dirfd, const char *pathname, unsigned int flags)
+static int open_tree(int dirfd, const char *pathname, unsigned int flags)
 {
 	return tst_syscall(__NR_open_tree, dirfd, pathname, flags);
 }
@@ -130,7 +130,7 @@ enum fsconfig_command {
 
 #endif /* OPEN_TREE_CLONE */
 
-void fsopen_supported_by_kernel(void)
+static void fsopen_supported_by_kernel(void)
 {
 	if ((tst_kvercmp(5, 2, 0)) < 0) {
 		/* Check if the syscall is backported on an older kernel */

--- a/include/lapi/openat2.h
+++ b/include/lapi/openat2.h
@@ -47,7 +47,7 @@ struct open_how {
 					be scoped inside the dirfd
 					(similar to chroot(2)). */
 
-int openat2(int dfd, const char *pathname, struct open_how *how, size_t size)
+static int openat2(int dfd, const char *pathname, struct open_how *how, size_t size)
 {
 	return tst_syscall(__NR_openat2, dfd, pathname, how, size);
 }
@@ -59,7 +59,7 @@ struct open_how_pad {
 	uint64_t pad;
 };
 
-void openat2_supported_by_kernel(void)
+static void openat2_supported_by_kernel(void)
 {
 	if ((tst_kvercmp(5, 6, 0)) < 0) {
 		/* Check if the syscall is backported on an older kernel */

--- a/include/lapi/pidfd_open.h
+++ b/include/lapi/pidfd_open.h
@@ -15,7 +15,7 @@
 #include "config.h"
 
 #ifndef HAVE_PIDFD_OPEN
-int pidfd_open(pid_t pid, unsigned int flags)
+static int pidfd_open(pid_t pid, unsigned int flags)
 {
 	return tst_syscall(__NR_pidfd_open, pid, flags);
 }

--- a/include/lapi/preadv2.h
+++ b/include/lapi/preadv2.h
@@ -19,7 +19,7 @@
 /* LO_HI_LONG taken from glibc */
 # define LO_HI_LONG(val) (long) (val), (long) (((uint64_t) (val)) >> 32)
 
-ssize_t preadv2(int fd, const struct iovec *iov, int iovcnt, off_t offset,
+static ssize_t preadv2(int fd, const struct iovec *iov, int iovcnt, off_t offset,
 		int flags)
 {
 	return tst_syscall(__NR_preadv2, fd, iov, iovcnt,

--- a/include/lapi/pwritev2.h
+++ b/include/lapi/pwritev2.h
@@ -15,7 +15,7 @@
 /* LO_HI_LONG taken from glibc */
 # define LO_HI_LONG(val) (long) (val), (long) (((uint64_t) (val)) >> 32)
 
-ssize_t pwritev2(int fd, const struct iovec *iov, int iovcnt, off_t offset,
+static ssize_t pwritev2(int fd, const struct iovec *iov, int iovcnt, off_t offset,
 		int flags)
 {
 	return tst_syscall(__NR_pwritev2, fd, iov, iovcnt,

--- a/include/lapi/sched.h
+++ b/include/lapi/sched.h
@@ -28,14 +28,14 @@ struct sched_attr {
 	uint64_t sched_period;
 };
 
-int sched_setattr(pid_t pid,
+static int sched_setattr(pid_t pid,
 	const struct sched_attr *attr,
 	unsigned int flags)
 {
 	return syscall(__NR_sched_setattr, pid, attr, flags);
 }
 
-int sched_getattr(pid_t pid,
+static int sched_getattr(pid_t pid,
 	struct sched_attr *attr,
 	unsigned int size,
 	unsigned int flags)

--- a/include/lapi/splice.h
+++ b/include/lapi/splice.h
@@ -11,7 +11,7 @@
 #include "lapi/syscalls.h"
 
 #if !defined(HAVE_SPLICE)
-ssize_t splice(int fd_in, loff_t *off_in, int fd_out,
+static ssize_t splice(int fd_in, loff_t *off_in, int fd_out,
 	loff_t *off_out, size_t len, unsigned int flags)
 {
 	return tst_syscall(__NR_splice, fd_in, off_in,

--- a/include/lapi/tee.h
+++ b/include/lapi/tee.h
@@ -11,7 +11,7 @@
 #include "lapi/syscalls.h"
 
 #if !defined(HAVE_TEE)
-ssize_t tee(int fd_in, int fd_out, size_t len, unsigned int flags)
+static ssize_t tee(int fd_in, int fd_out, size_t len, unsigned int flags)
 {
 	return tst_syscall(__NR_tee, fd_in, fd_out, len, flags);
 }

--- a/include/lapi/vmsplice.h
+++ b/include/lapi/vmsplice.h
@@ -13,7 +13,7 @@
 #include "lapi/iovec.h"
 
 #if !defined(HAVE_VMSPLICE)
-ssize_t vmsplice(int fd, const struct iovec *iov,
+static ssize_t vmsplice(int fd, const struct iovec *iov,
 	         unsigned long nr_segs, unsigned int flags)
 {
 	return tst_syscall(__NR_vmsplice, fd, iov, nr_segs, flags);

--- a/include/old/test.h
+++ b/include/old/test.h
@@ -209,6 +209,6 @@ const char *tst_strerrno(int err);
 #else
 #define TCID_BIT_SUFFIX ""
 #endif
-#define TCID_DEFINE(ID) char *TCID = (#ID TCID_BIT_SUFFIX)
+#define TCID_DEFINE(ID) static char *TCID = (#ID TCID_BIT_SUFFIX)
 
 #endif	/* __TEST_H__ */

--- a/include/old/usctest.h
+++ b/include/old/usctest.h
@@ -51,8 +51,8 @@
  ***********************************************************************/
 extern int STD_LOOP_COUNT; /* changed by -in to set loop count to n */
 
-extern long TEST_RETURN;
-extern int TEST_ERRNO;
+static long TEST_RETURN;
+static int TEST_ERRNO;
 
 /***********************************************************************
  * TEST: calls a system call

--- a/lib/parse_opts.c
+++ b/lib/parse_opts.c
@@ -576,8 +576,8 @@ int Help = 0;
 int Help2 = 0;
 char *ptr;
 
-long TEST_RETURN;
-int TEST_ERRNO;
+static long TEST_RETURN;
+static int TEST_ERRNO;
 
 /* for test specific parse_opts options */
 option_t Options[] = {

--- a/lib/tst_res.c
+++ b/lib/tst_res.c
@@ -53,8 +53,8 @@
 #include "ltp_priv.h"
 #include "tst_ansi_color.h"
 
-long TEST_RETURN;
-int TEST_ERRNO;
+static long TEST_RETURN;
+static int TEST_ERRNO;
 void *TST_RET_PTR;
 
 #define VERBOSE      1

--- a/lib/tst_status.c
+++ b/lib/tst_status.c
@@ -18,7 +18,7 @@ const char *exited(int status)
 	return buf;
 }
 
-const char *signaled(int status)
+static const char *signaled(int status)
 {
 	snprintf(buf, sizeof(buf), "killed by %s", tst_strsig(status));
 

--- a/testcases/kernel/containers/share/setns_check.c
+++ b/testcases/kernel/containers/share/setns_check.c
@@ -21,7 +21,7 @@
 #include "test.h"
 #include "lapi/syscalls.h"
 
-char *TCID = "setns_check";
+static char *TCID = "setns_check";
 
 int main(void)
 {

--- a/testcases/kernel/controllers/cgroup_fj/cgroup_fj_proc.c
+++ b/testcases/kernel/controllers/cgroup_fj/cgroup_fj_proc.c
@@ -33,7 +33,7 @@
 
 static int test_switch = 0;
 
-void sighandler(UNUSED int signo)
+static void sighandler(UNUSED int signo)
 {
 	test_switch = !test_switch;
 }

--- a/testcases/kernel/controllers/cpuctl_fj/cpuctl_fj_cpu-hog.c
+++ b/testcases/kernel/controllers/cpuctl_fj/cpuctl_fj_cpu-hog.c
@@ -36,7 +36,7 @@ unsigned long count;
 volatile int start = 0;
 volatile double f = 2744545.34456455;
 
-void sighandler(UNUSED int signo)
+static void sighandler(UNUSED int signo)
 {
 	start = !start;
 }

--- a/testcases/kernel/controllers/memcg/regression/memcg_test_2.c
+++ b/testcases/kernel/controllers/memcg/regression/memcg_test_2.c
@@ -26,7 +26,7 @@
 #include <string.h>
 #include <unistd.h>
 
-void sigusr_handler(int __attribute__ ((unused)) signo)
+static void sigusr_handler(int __attribute__ ((unused)) signo)
 {
 	char *p;
 	int size = getpagesize() * 2;

--- a/testcases/kernel/controllers/memcg/regression/memcg_test_4.c
+++ b/testcases/kernel/controllers/memcg/regression/memcg_test_4.c
@@ -31,7 +31,7 @@
 
 #define MEM_SIZE	(1024 * 1024 * 100)
 
-void sigusr_handler(int __attribute__ ((unused)) signo)
+static void sigusr_handler(int __attribute__ ((unused)) signo)
 {
 	char *p;
 

--- a/testcases/kernel/controllers/memcg/stress/memcg_process_stress.c
+++ b/testcases/kernel/controllers/memcg/stress/memcg_process_stress.c
@@ -12,16 +12,16 @@
 #include <string.h>
 #include <unistd.h>
 
-int flag_exit;
+static int flag_exit;
 int flag_ready;
 
 int interval;
-unsigned long memsize;
+static unsigned long memsize;
 
 char **pages;
 int nr_page;
 
-void touch_memory(void)
+static void touch_memory(void)
 {
 	int i;
 
@@ -29,7 +29,7 @@ void touch_memory(void)
 		pages[i][0] = 0xef;
 }
 
-void sigusr_handler(int __attribute__ ((unused)) signo)
+static void sigusr_handler(int __attribute__ ((unused)) signo)
 {
 	int i;
 	int pagesize;

--- a/testcases/kernel/controllers/memctl/memctl_test01.c
+++ b/testcases/kernel/controllers/memctl/memctl_test01.c
@@ -49,8 +49,8 @@
 #include "libcontrollers.h"
 #include "test.h"
 
-char *TCID = "memory_controller_test01-03";
-int TST_TOTAL = 3;
+static char *TCID = "memory_controller_test01-03";
+static int TST_TOTAL = 3;
 
 pid_t scriptpid;
 typedef size_t record_t;
@@ -58,7 +58,7 @@ record_t **array_of_chunks;
 record_t tmp;
 int num_of_chunks, chunk_size, test_num, limit;
 
-void cleanup();
+static void cleanup();
 void signal_handler_sigusr1(int signal);
 void signal_handler_sigusr2(int signal);
 int allocate_memory(void);
@@ -120,7 +120,7 @@ int main(void)
  * Function: cleanup()
  * signals for system cleanup in case test breaks
  */
-void cleanup(void)
+static void cleanup(void)
 {
 	if (kill(scriptpid, SIGUSR1) == -1)
 		tst_resm(TWARN | TERRNO, "kill failed");

--- a/testcases/kernel/device-drivers/cpufreq/cpufreq_boost.c
+++ b/testcases/kernel/device-drivers/cpufreq/cpufreq_boost.c
@@ -36,7 +36,7 @@
 #include "lapi/posix_clocks.h"
 #include "safe_macros.h"
 
-char *TCID = "cpufreq_boost";
+static char *TCID = "cpufreq_boost";
 
 #define SYSFS_CPU_DIR "/sys/devices/system/cpu/"
 

--- a/testcases/kernel/device-drivers/zram/zram03.c
+++ b/testcases/kernel/device-drivers/zram/zram03.c
@@ -36,8 +36,8 @@
 #include "test.h"
 #include "safe_macros.h"
 
-char *TCID = "zram03";
-int TST_TOTAL = 1;
+static char *TCID = "zram03";
+static int TST_TOTAL = 1;
 
 #define PATH_ZRAM	"/sys/block/zram0"
 #define OBSOLETE_ZRAM_FILE	"/sys/block/zram0/num_reads"

--- a/testcases/kernel/fs/doio/iogen.c
+++ b/testcases/kernel/fs/doio/iogen.c
@@ -122,8 +122,8 @@ int str_to_value(struct strmap *map, char *str);
 struct strmap *str_lookup(struct strmap *map, char *str);
 char *value_to_string(struct strmap *map, int val);
 int parse_cmdline(int argc, char **argv, char *opts);
-int help(FILE * stream);
-int usage(FILE * stream);
+static int help(FILE * stream);
+static int usage(FILE * stream);
 
 /*
  * Declare cmdline option flags/variables initialized in parse_cmdline()
@@ -1932,7 +1932,7 @@ int parse_cmdline(int argc, char **argv, char *opts)
 	return 0;
 }
 
-int help(FILE * stream)
+static int help(FILE * stream)
 {
 	usage(stream);
 	fprintf(stream, "\n");
@@ -2090,7 +2090,7 @@ int help(FILE * stream)
  * Obvious - usage clause
  */
 
-int usage(FILE * stream)
+static int usage(FILE * stream)
 {
 	fprintf(stream,
 		"usage%s:  iogen [-hoq] [-a aio_type,...] [-f flag[,flag...]] [-i iterations] [-p outpipe] [-m offset-mode] [-s syscall[,syscall...]] [-t mintrans] [-T maxtrans] [ -O file-create-flags ] [[len:]file ...]\n",

--- a/testcases/kernel/fs/fs-bench/create-files.c
+++ b/testcases/kernel/fs/fs-bench/create-files.c
@@ -15,9 +15,9 @@
 char wbuf[MAXFSIZE];
 static int filecount = 0;
 
-void makedir(char *dir1);
-void changedir(char *dir);
-void create_file(char *filename);
+static void makedir(char *dir1);
+static void changedir(char *dir);
+static void create_file(char *filename);
 
 extern int box_muler(int, int);
 
@@ -79,9 +79,9 @@ end:
 	return 0;
 }
 
-int showchar[] = { 124, 47, 45, 92, 124, 47, 45, 92 };
+static int showchar[] = { 124, 47, 45, 92, 124, 47, 45, 92 };
 
-void makedir(char *dir1)
+static void makedir(char *dir1)
 {
 	if (mkdir(dir1, S_IRWXU) < 0) {
 		perror(dir1);
@@ -89,7 +89,7 @@ void makedir(char *dir1)
 	}
 }
 
-void changedir(char *dir)
+static void changedir(char *dir)
 {
 	if (chdir(dir) < 0) {
 		perror(dir);
@@ -97,7 +97,7 @@ void changedir(char *dir)
 	}
 }
 
-void create_file(char *filename)
+static void create_file(char *filename)
 {
 	int fd;
 	int randomsize;

--- a/testcases/kernel/fs/fs-bench/random-access-del-create.c
+++ b/testcases/kernel/fs/fs-bench/random-access-del-create.c
@@ -11,17 +11,17 @@
 #define FAIL 0
 #define SUCCESS 1
 
-int openlog[2] = { 0, 0 };
+static int openlog[2] = { 0, 0 };
 
 #define MAXNUM 0x100000
 
 #define  MAXERROR 1024
 
 extern int box_muler(int, int);
-extern void create_or_delete(char *);
+static void create_or_delete(char *);
 
-int delete_file(char *filename);
-int create_file(char *filename);
+static int delete_file(char *filename);
+static int create_file(char *filename);
 
 int cfilecount = 0;
 int dfilecount = 0;
@@ -70,7 +70,7 @@ int main(int ac, char **av)
 #define POOLDISKSPACE (AVEFSIZE*128)
 
 static int disk_space_pool = 0;
-void create_or_delete(char *fname)
+static void create_or_delete(char *fname)
 {
 	int r;
 
@@ -91,7 +91,7 @@ void create_or_delete(char *fname)
 	}
 }
 
-int create_file(char *filename)
+static int create_file(char *filename)
 {
 	int fd;
 	int randomsize;
@@ -118,7 +118,7 @@ int create_file(char *filename)
 #include <sys/stat.h>
 #include <unistd.h>
 
-int delete_file(char *filename)
+static int delete_file(char *filename)
 {
 	struct stat buf;
 	int st;

--- a/testcases/kernel/fs/fs-bench/random-access.c
+++ b/testcases/kernel/fs/fs-bench/random-access.c
@@ -11,7 +11,7 @@
 #define FAIL 0
 #define SUCCESS 1
 
-int openlog[2] = { 0, 0 };
+static int openlog[2] = { 0, 0 };
 
 #define MAXNUM 0x100000
 

--- a/testcases/kernel/fs/fs-bench/random-del-create.c
+++ b/testcases/kernel/fs/fs-bench/random-del-create.c
@@ -11,18 +11,18 @@
 #define FAIL 0
 #define SUCCESS 1
 
-int openlog[2] = { 0, 0 };
+static int openlog[2] = { 0, 0 };
 
 #define MAXNUM 0x100000
 
 #define  MAXERROR 1024
 
 extern int box_muler(int, int);
-extern void create_or_delete(char *);
+static void create_or_delete(char *);
 
-int cfilecount = 0;
-int dfilecount = 0;
-int errorcount = 0;
+static int cfilecount = 0;
+static int dfilecount = 0;
+static int errorcount = 0;
 
 int main(int ac, char **av)
 {
@@ -67,7 +67,10 @@ int main(int ac, char **av)
 #define POOLDISKSPACE (AVEFSIZE*128)
 
 static int disk_space_pool = 0;
-void create_or_delete(char *fname)
+static int create_file(char *filename);
+static int delete_file(char *filename);
+
+static void create_or_delete(char *fname)
 {
 	int r;
 	int fsize;
@@ -89,7 +92,7 @@ void create_or_delete(char *fname)
 	}
 }
 
-int create_file(char *filename)
+static int create_file(char *filename)
 {
 	int fd;
 	int randomsize;
@@ -115,7 +118,7 @@ int create_file(char *filename)
 #include <sys/stat.h>
 #include <unistd.h>
 
-int delete_file(char *filename)
+static int delete_file(char *filename)
 {
 	struct stat buf;
 	int st;

--- a/testcases/kernel/fs/inode/inode01.c
+++ b/testcases/kernel/fs/inode/inode01.c
@@ -64,33 +64,33 @@ CALLS:	mkdir, stat, open
 /** LTP Port **/
 #include "test.h"
 
-void blexit(void);
-void blenter(void);
-void setup(void);
-void fail_exit(void);
-void anyfail(void);
-void ok_exit(void);
+static void blexit(void);
+static void blenter(void);
+static void setup(void);
+static void fail_exit(void);
+static void anyfail(void);
+static void ok_exit(void);
 
 #define FAILED 0
 #define PASSED 1
 
-int local_flag = PASSED;
-int block_number;
-FILE *temp;
+static int local_flag = PASSED;
+static int block_number;
+static FILE *temp;
 
-char *TCID = "inode01";		/* Test program identifier.    */
-int TST_TOTAL = 2;		/* Total number of test cases. */
+static char *TCID = "inode01";		/* Test program identifier.    */
+static int TST_TOTAL = 2;		/* Total number of test cases. */
 /**************/
 
 #ifdef LINUX
 #include <string.h>
 #endif
 
-char name[NAME_LENGTH + 1];
-char path_string[PATH_STRING_LENGTH + 1];
-char read_string[PATH_STRING_LENGTH + 1];
-char write_string[PATH_STRING_LENGTH + 1];
-char rm_string[200];
+static char name[NAME_LENGTH + 1];
+static char path_string[PATH_STRING_LENGTH + 1];
+static char read_string[PATH_STRING_LENGTH + 1];
+static char write_string[PATH_STRING_LENGTH + 1];
+static char rm_string[200];
 
 FILE *list_stream = NULL;
 int file_id;
@@ -709,7 +709,7 @@ int term(void)
  *
  * Do set up - here its a dummy function
  */
-void setup(void)
+static void setup(void)
 {
 	tst_tmpdir();
 	temp = stderr;
@@ -724,7 +724,7 @@ gical unit
 fail or
  *              pass.
  */
-void blexit(void)
+static void blexit(void)
 {
 	(local_flag == PASSED) ? tst_resm(TPASS, "Test block %d", block_number)
 	    : tst_resm(TFAIL, "Test block %d", block_number);
@@ -737,7 +737,7 @@ void blexit(void)
  *
  * Description: Print message on entering a new block
  */
-void blenter(void)
+static void blenter(void)
 {
 	local_flag = PASSED;
 	return;
@@ -748,7 +748,7 @@ void blenter(void)
  *
  * Exit on failure
  */
-void fail_exit(void)
+static void fail_exit(void)
 {
 	tst_brkm(TFAIL, tst_rmdir, "Test failed");
 }
@@ -759,7 +759,7 @@ void fail_exit(void)
  *
  * Description: Exit a test.
  */
-void anyfail(void)
+static void anyfail(void)
 {
 	(local_flag == FAILED) ? tst_resm(TFAIL, "Test failed")
 	    : tst_resm(TPASS, "Test passed");
@@ -772,7 +772,7 @@ void anyfail(void)
  *
  * Calling block passed the test
  */
-void ok_exit(void)
+static void ok_exit(void)
 {
 	local_flag = PASSED;
 	return;

--- a/testcases/kernel/fs/inode/inode02.c
+++ b/testcases/kernel/fs/inode/inode02.c
@@ -67,23 +67,23 @@ CALLS:	mkdir, stat, open
 #endif
 
 #define MAXCHILD	25
-int allchild[MAXCHILD + 1];
+static int allchild[MAXCHILD + 1];
 
-char name[NAME_LENGTH + 1];
-char path_string[PATH_STRING_LENGTH + 1];
-char read_string[PATH_STRING_LENGTH + 1];
-char write_string[PATH_STRING_LENGTH + 1];
-char remove_string[PATH_STRING_LENGTH + 10];
-int parent_pid;
-int nchild;
+static char name[NAME_LENGTH + 1];
+static char path_string[PATH_STRING_LENGTH + 1];
+static char read_string[PATH_STRING_LENGTH + 1];
+static char write_string[PATH_STRING_LENGTH + 1];
+static char remove_string[PATH_STRING_LENGTH + 10];
+static int parent_pid;
+static int nchild;
 
-FILE *list_stream = NULL;
-int list_id;
-int file_id;
+static FILE *list_stream = NULL;
+static int list_id;
+static int file_id;
 
-int increment_name(), get_next_name(), mode(), escrivez(), massmurder();
-int max_depth, max_breadth, file_length;
-int bd_arg(char *);
+static int increment_name(), get_next_name(), mode(), escrivez(), massmurder();
+static int max_depth, max_breadth, file_length;
+static int bd_arg(char *);
 
 #ifdef LINUX
 void (*sigset(int, void (*)(int))) (int);
@@ -92,30 +92,35 @@ void (*sigset(int, void (*)(int))) (int);
 /** LTP Port **/
 #include "test.h"
 
-void setup(void);
-void fail_exit(void);
-void anyfail(void);
-void ok_exit(void);
-void forkfail(void);
-void terror(char *);
-int instress(void);
+static void setup(void);
+static void fail_exit(void);
+static void anyfail(void);
+static void ok_exit(void);
+static void forkfail(void);
+static void terror(char *);
+static int instress(void);
 
 #define FAILED 0
 #define PASSED 1
 
-int local_flag = PASSED;
-FILE *temp;
+static int local_flag = PASSED;
+static FILE *temp;
 
-char *TCID = "inode02";		/* Test program identifier.    */
-int TST_TOTAL = 1;		/* Total number of test cases. */
+static char *TCID = "inode02";		/* Test program identifier.    */
+static int TST_TOTAL = 1;		/* Total number of test cases. */
+
+static int term();
+static int generate(), check();
+
+static int tree();
+
 /**************/
 
 int main(int argc, char *argv[])
 {
-	int pid, tree(), p, status;
+	int pid, p, status;
 	int count, child;
 	register int i;
-	int term();
 
 	setup();
 
@@ -214,7 +219,7 @@ int main(int argc, char *argv[])
 	tst_exit();
 }
 
-int bd_arg(char *str)
+static int bd_arg(char *str)
 {
 	fprintf(temp,
 		"Bad argument - %s - could not parse as number.\n\tinode02 [max_depth] [max_breadth] [file_length] [#children]\n\tdefault: inode02 6 5 8 5\n",
@@ -222,7 +227,7 @@ int bd_arg(char *str)
 	exit(1);
 }
 
-int tree(void)
+static int tree(void)
 
 /************************************************/
 /*						*/
@@ -240,7 +245,6 @@ int tree(void)
 {
 	int gen_ret_val, ch_ret_val, exit_val, level;
 	int ret_val;
-	int generate(), check();
 	char path_list_string[PATH_STRING_LENGTH + 10];
 	int len;
 	int status;
@@ -372,7 +376,7 @@ int tree(void)
 	exit(exit_val);
 }
 
-int generate(char *string, int level)
+static int generate(char *string, int level)
 
 /****************************************/
 /*					*/
@@ -554,7 +558,7 @@ int generate(char *string, int level)
 		return 0;
 }
 
-int check(void)
+static int check(void)
 
 /****************************************/
 /*					*/
@@ -672,7 +676,7 @@ int check(void)
 	}			/* while */
 }
 
-int get_next_name(void)
+static int get_next_name(void)
 
 /****************************************/
 /*					*/
@@ -709,7 +713,7 @@ int get_next_name(void)
 	return 0;
 }
 
-int increment_name(int position)
+static int increment_name(int position)
 
 /****************************************/
 /*					*/
@@ -742,7 +746,7 @@ int increment_name(int position)
 				  /*********************************/
 }
 
-int mode(char *path_string)
+static int mode(char *path_string)
 
 /****************************************/
 /*					*/
@@ -763,7 +767,7 @@ int mode(char *path_string)
 	}
 }
 
-int escrivez(char *string)
+static int escrivez(char *string)
 {
 	char write_string[PATH_STRING_LENGTH + 1];
 	int len, ret_len;
@@ -782,7 +786,7 @@ int escrivez(char *string)
 	return 0;
 }
 
-int term(void)
+static int term(void)
 {
 	int status;
 
@@ -807,7 +811,7 @@ int term(void)
 	return 0;
 }
 
-int massmurder(void)
+static int massmurder(void)
 {
 	int i;
 	for (i = 0; i < MAXCHILD; i++) {
@@ -824,7 +828,7 @@ int massmurder(void)
  *
  * Do set up - here its a dummy function
  */
-void setup(void)
+static void setup(void)
 {
 	tst_tmpdir();
 	temp = stderr;
@@ -835,7 +839,7 @@ void setup(void)
  *
  * Exit on failure
  */
-void fail_exit(void)
+static void fail_exit(void)
 {
 	tst_brkm(TFAIL, tst_rmdir, "Test failed\n");
 }
@@ -846,7 +850,7 @@ void fail_exit(void)
  *
  * Description: Exit a test.
  */
-void anyfail(void)
+static void anyfail(void)
 {
 	(local_flag == FAILED) ? tst_resm(TFAIL, "Test failed")
 	    : tst_resm(TPASS, "Test passed");
@@ -859,7 +863,7 @@ void anyfail(void)
  *
  * Calling block passed the test
  */
-void ok_exit(void)
+static void ok_exit(void)
 {
 	local_flag = PASSED;
 	return;
@@ -870,7 +874,7 @@ void ok_exit(void)
  *
  * exit on failure
  */
-void forkfail(void)
+static void forkfail(void)
 {
 	tst_brkm(TBROK, tst_rmdir, "Reason: %s\n", strerror(errno));
 }
@@ -882,7 +886,7 @@ void forkfail(void)
  *              test case failed, for example fork() failed. We will log this
  *              failure as TBROK instead of TFAIL.
  */
-void terror(char *message)
+static void terror(char *message)
 {
 	tst_resm(TBROK, "Reason: %s:%s\n", message, strerror(errno));
 	return;
@@ -894,7 +898,7 @@ void terror(char *message)
  * Assume that we are always running under stress, so this function will
  * return > 0 value always.
  */
-int instress(void)
+static int instress(void)
 {
 	tst_resm(TINFO, "System resource may be too low, fork() malloc()"
 		 " etc are likely to fail.\n");

--- a/testcases/kernel/fs/mongo/reiser_fract_tree.c
+++ b/testcases/kernel/fs/mongo/reiser_fract_tree.c
@@ -12,7 +12,7 @@
 #include <fcntl.h>
 #include <errno.h>
 char tdir[256];
-char path[256];
+static char path[256];
 long stats = 0;
 
 void print_usage()

--- a/testcases/kernel/fs/openfile/openfile.c
+++ b/testcases/kernel/fs/openfile/openfile.c
@@ -37,8 +37,8 @@
 
 #include "test.h"
 
-char *TCID = "openfile01";	/* Test program identifier.    */
-int TST_TOTAL = 1;
+static char *TCID = "openfile01";	/* Test program identifier.    */
+static int TST_TOTAL = 1;
 
 #define MAXFILES        32768
 #define MAXTHREADS      10
@@ -53,15 +53,15 @@ struct cb {
 
 /* Global Variables */
 int numthreads = 10, numfiles = 10;
-int debug = 0;
+static int debug = 0;
 char *filename = "FILETOOPEN";
 
-void setup(void)
+static void setup(void)
 {
 	tst_tmpdir();
 }
 
-void cleanup(void)
+static void cleanup(void)
 {
 	tst_rmdir();
 

--- a/testcases/kernel/fs/proc/proc01.c
+++ b/testcases/kernel/fs/proc/proc01.c
@@ -48,8 +48,8 @@
 #define MAX_BUFF_SIZE 65536
 #define MAX_FUNC_NAME 256
 
-char *TCID = "proc01";
-int TST_TOTAL = 1;
+static char *TCID = "proc01";
+static int TST_TOTAL = 1;
 
 static int opt_verbose;
 static int opt_procpath;

--- a/testcases/kernel/fs/scsi/ltpfs/main.c
+++ b/testcases/kernel/fs/scsi/ltpfs/main.c
@@ -38,7 +38,7 @@ int startc = 0;
 int showchar[] = { 124, 47, 45, 92, 124, 47, 45, 92 };
 
 int nullFileHandle;
-int openlog[2] = { 0, 0 };
+static int openlog[2] = { 0, 0 };
 
 int cFileCount, dFileCount, errorCount;
 static int disk_space_pool = 0;
@@ -51,8 +51,8 @@ int makedir(char *dir1);
 int changedir(char *dir);
 int do_random_access_test(int maxNum);
 int do_random_create_delete(int maxNum);
-int create_file(char *filename);
-int delete_file(char *filename);
+static int create_file(char *filename);
+static int delete_file(char *filename);
 int gen_random_file_size(int min, int max);
 int open_read_close(char *fname);
 int create_or_delete(char *fname);
@@ -329,7 +329,7 @@ int changedir(char *dir)
 	return 0;
 }
 
-int create_file(char *filename)
+static int create_file(char *filename)
 {
 	int fileHandle;
 	int randomsize;
@@ -360,7 +360,7 @@ int create_file(char *filename)
 	return 0;
 }
 
-int delete_file(char *filename)
+static int delete_file(char *filename)
 {
 	struct stat buf;
 	int st;

--- a/testcases/kernel/fs/stream/stream01.c
+++ b/testcases/kernel/fs/stream/stream01.c
@@ -33,18 +33,18 @@
 #include <errno.h>
 #include "test.h"
 
-char *TCID = "stream01";
-int TST_TOTAL = 1;
-int local_flag;
+static char *TCID = "stream01";
+static int TST_TOTAL = 1;
+static int local_flag;
 
 #define PASSED 1
 #define FAILED 0
 
 /* XXX: add setup and cleanup. */
 
-char progname[] = "stream01()";
-char tempfile1[40] = "";
-char tempfile2[40] = "";
+static char progname[] = "stream01()";
+static char tempfile1[40] = "";
+static char tempfile2[40] = "";
 
 /*--------------------------------------------------------------------*/
 int main(int ac, char *av[])

--- a/testcases/kernel/fs/stream/stream02.c
+++ b/testcases/kernel/fs/stream/stream02.c
@@ -34,9 +34,9 @@
 #include <sys/stat.h>
 #include "test.h"
 
-char *TCID = "stream02";
-int TST_TOTAL = 1;
-int local_flag;
+static char *TCID = "stream02";
+static int TST_TOTAL = 1;
+static int local_flag;
 
 #define PASSED 1
 #define FAILED 0

--- a/testcases/kernel/fs/stream/stream03.c
+++ b/testcases/kernel/fs/stream/stream03.c
@@ -36,15 +36,15 @@
 #include <inttypes.h>
 #include "test.h"
 
-char *TCID = "stream03";
-int TST_TOTAL = 1;
-int local_flag;
+static char *TCID = "stream03";
+static int TST_TOTAL = 1;
+static int local_flag;
 
 #define PASSED 1
 #define FAILED 0
 
-char progname[] = "stream03()";
-char tempfile1[40] = "";
+static char progname[] = "stream03()";
+static char tempfile1[40] = "";
 
 int main(int ac, char *av[])
 {

--- a/testcases/kernel/fs/stream/stream04.c
+++ b/testcases/kernel/fs/stream/stream04.c
@@ -37,15 +37,15 @@
 #include <sys/stat.h>
 #include "test.h"
 
-char *TCID = "stream04";
-int TST_TOTAL = 1;
-int local_flag;
+static char *TCID = "stream04";
+static int TST_TOTAL = 1;
+static int local_flag;
 
 #define PASSED 1
 #define FAILED 0
 
-char progname[] = "stream04()";
-char tempfile1[40] = "";
+static char progname[] = "stream04()";
+static char tempfile1[40] = "";
 long ftell();
 
 /* XXX: add setup and cleanup */

--- a/testcases/kernel/fs/stream/stream05.c
+++ b/testcases/kernel/fs/stream/stream05.c
@@ -41,15 +41,15 @@
 #include <errno.h>
 #include "test.h"
 
-char *TCID = "stream05";
-int TST_TOTAL = 1;
-int local_flag;
+static char *TCID = "stream05";
+static int TST_TOTAL = 1;
+static int local_flag;
 
 #define PASSED 1
 #define FAILED 0
 
-char progname[] = "stream05()";
-char tempfile[40] = "";
+static char progname[] = "stream05()";
+static char tempfile[40] = "";
 
 /*--------------------------------------------------------------------*/
 int main(int ac, char *av[])

--- a/testcases/kernel/io/direct_io/diotest2.c
+++ b/testcases/kernel/io/direct_io/diotest2.c
@@ -57,8 +57,8 @@
 
 #include "test.h"
 
-char *TCID = "diotest02";	/* Test program identifier.    */
-int TST_TOTAL = 3;		/* Total number of test conditions */
+static char *TCID = "diotest02";	/* Test program identifier.    */
+static int TST_TOTAL = 3;		/* Total number of test conditions */
 
 #ifdef O_DIRECT
 

--- a/testcases/kernel/io/direct_io/diotest3.c
+++ b/testcases/kernel/io/direct_io/diotest3.c
@@ -57,8 +57,8 @@
 
 #include "test.h"
 
-char *TCID = "diotest03";	/* Test program identifier.    */
-int TST_TOTAL = 3;		/* Total number of test conditions */
+static char *TCID = "diotest03";	/* Test program identifier.    */
+static int TST_TOTAL = 3;		/* Total number of test conditions */
 
 #ifdef O_DIRECT
 
@@ -88,7 +88,7 @@ static void prg_usage(void)
  *
  * XXX (garrcoop): shouldn't use libltp APIs because it runs forked.
  */
-int runtest(int fd_r, int fd_w, int childnum, int action)
+static int runtest(int fd_r, int fd_w, int childnum, int action)
 {
 	char *buf1;
 	char *buf2;

--- a/testcases/kernel/io/direct_io/diotest4.c
+++ b/testcases/kernel/io/direct_io/diotest4.c
@@ -72,8 +72,8 @@
 #include "safe_macros.h"
 #include "lapi/mmap.h"
 
-char *TCID = "diotest4";	/* Test program identifier.    */
-int TST_TOTAL = 17;		/* Total number of test conditions */
+static char *TCID = "diotest4";	/* Test program identifier.    */
+static int TST_TOTAL = 17;		/* Total number of test conditions */
 
 static long fs_type;
 

--- a/testcases/kernel/io/direct_io/diotest5.c
+++ b/testcases/kernel/io/direct_io/diotest5.c
@@ -60,8 +60,8 @@
 
 #include "test.h"
 
-char *TCID = "diotest05";	/* Test program identifier.    */
-int TST_TOTAL = 3;		/* Total number of test conditions */
+static char *TCID = "diotest05";	/* Test program identifier.    */
+static int TST_TOTAL = 3;		/* Total number of test conditions */
 
 #ifdef O_DIRECT
 
@@ -82,7 +82,7 @@ static int fd1 = -1;
  * runtest: Write the data in vector array to the file. Read the data
  *	from the file into another vectory array and verify. Repeat the test.
 */
-int runtest(int fd_r, int fd_w, int iter, off64_t offset, int action)
+static int runtest(int fd_r, int fd_w, int iter, off64_t offset, int action)
 {
 	int i;
 	struct iovec *iov1, *iov2, *iovp;

--- a/testcases/kernel/io/direct_io/diotest6.c
+++ b/testcases/kernel/io/direct_io/diotest6.c
@@ -48,8 +48,8 @@
 
 #include "test.h"
 
-char *TCID = "diotest06";
-int TST_TOTAL = 3;
+static char *TCID = "diotest06";
+static int TST_TOTAL = 3;
 
 #ifdef O_DIRECT
 
@@ -82,7 +82,7 @@ static void prg_usage(void)
  *	For each iteration, write data starting at offse+iter*bufsize
  *	location in the file and read from there.
 */
-int runtest(int fd_r, int fd_w, int childnum, int action)
+static int runtest(int fd_r, int fd_w, int childnum, int action)
 {
 	off64_t seekoff;
 	int i, ret = -1;
@@ -171,7 +171,7 @@ err:
 /*
  * child_function: open the file for read and write. Call the runtest routine.
 */
-int child_function(int childnum, int action)
+static int child_function(int childnum, int action)
 {
 	int fd_w, fd_r;
 

--- a/testcases/kernel/io/ltp-aiodio/aiodio_append.c
+++ b/testcases/kernel/io/ltp-aiodio/aiodio_append.c
@@ -35,7 +35,7 @@
 #include "config.h"
 #include "test.h"
 
-char *TCID = "aiodio_append";
+static char *TCID = "aiodio_append";
 
 #ifdef HAVE_LIBAIO
 #include <libaio.h>

--- a/testcases/kernel/io/ltp-aiodio/dio_append.c
+++ b/testcases/kernel/io/ltp-aiodio/dio_append.c
@@ -47,7 +47,7 @@
 
 #include "common_checkzero.h"
 
-int read_eof(char *filename)
+static int read_eof(char *filename)
 {
 	int fd;
 	int i;
@@ -75,7 +75,7 @@ int read_eof(char *filename)
 	return 0;
 }
 
-void dio_append(char *filename)
+static void dio_append(char *filename)
 {
 	int fd;
 	void *bufptr;

--- a/testcases/kernel/io/ltp-aiodio/dio_sparse.c
+++ b/testcases/kernel/io/ltp-aiodio/dio_sparse.c
@@ -47,8 +47,8 @@ static void usage(void);
 static int debug = 0;
 static int fd;
 
-char *TCID = "dio_sparse";
-int TST_TOTAL = 1;
+static char *TCID = "dio_sparse";
+static int TST_TOTAL = 1;
 
 #include "common_sparse.h"
 

--- a/testcases/kernel/io/ltp-aiodio/dio_truncate.c
+++ b/testcases/kernel/io/ltp-aiodio/dio_truncate.c
@@ -42,7 +42,7 @@
 
 #define NUM_CHILDREN 8
 
-char *check_zero(unsigned char *buf, int size)
+static char *check_zero(unsigned char *buf, int size)
 {
 	unsigned char *p;
 
@@ -65,7 +65,7 @@ char *check_zero(unsigned char *buf, int size)
 	return 0;		/* all zeros */
 }
 
-int dio_read(char *filename)
+static int dio_read(char *filename)
 {
 	int fd;
 	int r;
@@ -102,7 +102,7 @@ int dio_read(char *filename)
 	return 0;
 }
 
-void dio_append(char *filename, int fill)
+static void dio_append(char *filename, int fill)
 {
 	int fd;
 	void *bufptr;

--- a/testcases/kernel/io/ltp-aiodio/read_checkzero.c
+++ b/testcases/kernel/io/ltp-aiodio/read_checkzero.c
@@ -35,7 +35,7 @@
 
 #include "common_checkzero.h"
 
-int read_eof(char *filename)
+static int read_eof(char *filename)
 {
 	int fd;
 	int i;

--- a/testcases/kernel/io/writetest/writetest.c
+++ b/testcases/kernel/io/writetest/writetest.c
@@ -53,8 +53,8 @@ int Verbosity = 0;
 int DefaultSeed = 0;
 char Filename[MAX_FILENAME_LEN] = FILE_OUT;
 off_t NumBlocks = 1;
-char *TCID = "writetest";
-int TST_TOTAL = 2;
+static char *TCID = "writetest";
+static int TST_TOTAL = 2;
 
 void buf_init(void)
 {
@@ -159,7 +159,7 @@ int verify_file(off_t num_blocks, const char *filename)
 	return (ret);
 }
 
-void usage(void)
+static void usage(void)
 {
 	printf("%s [-v] [-b blocks] [-s seed] [-o filename]\n", TCID);
 	printf("\n"
@@ -209,13 +209,13 @@ void parse_args(int argc, char **argv)
 	}
 }
 
-void setup()
+static void setup()
 {
 	tst_tmpdir();
 
 }
 
-void cleanup(void)
+static void cleanup(void)
 {
 	tst_rmdir();
 	tst_exit();

--- a/testcases/kernel/mem/mem/mem01.c
+++ b/testcases/kernel/mem/mem/mem01.c
@@ -52,8 +52,8 @@
  *  - make it multithreaded with random access to test r/w mm_sem
  */
 
-char *TCID = "mem01";
-int TST_TOTAL = 1;
+static char *TCID = "mem01";
+static int TST_TOTAL = 1;
 
 static int m_opt = 0;		/* memsize */
 static char *m_copt;
@@ -87,7 +87,7 @@ static void help(void)
  * return MemFree+SwapFree, from /proc/meminfo
  * returned value is in bytes.
  */
-size_t get_memsize(void)
+static size_t get_memsize(void)
 {
 	struct sysinfo info;
 	unsigned long long res;
@@ -136,7 +136,7 @@ size_t get_memsize(void)
  * add the -m option whose parameter is the
  * memory size (MB) to allocate.
  */
-option_t options[] = {
+static option_t options[] = {
 	{"m:", &m_opt, &m_copt}
 	,
 	{"r", &r_opt, NULL}

--- a/testcases/kernel/mem/mem/mem02.c
+++ b/testcases/kernel/mem/mem/mem02.c
@@ -52,8 +52,8 @@
 
 void on_mem_fault(int sig);
 
-char *TCID = "mem02";
-int TST_TOTAL = 1;
+static char *TCID = "mem02";
+static int TST_TOTAL = 1;
 
 static void usage(char *progname)
 {

--- a/testcases/kernel/mem/mmapstress/mmap-corruption01.c
+++ b/testcases/kernel/mem/mmapstress/mmap-corruption01.c
@@ -57,15 +57,15 @@
 extern int tst_count;
 
 /* Global Variables */
-char *TCID = "mmap-corruption01";	/* test program identifier.          */
-int TST_TOTAL = 1;		/* total number of tests in this file.   */
+static char *TCID = "mmap-corruption01";	/* test program identifier.          */
+static int TST_TOTAL = 1;		/* total number of tests in this file.   */
 
-long kMemSize = 128 << 20;
-int kPageSize = 4096;
+static long kMemSize = 128 << 20;
+static int kPageSize = 4096;
 
-char *usage = "-h hours -m minutes -s secs\n";
+static char *usage = "-h hours -m minutes -s secs\n";
 
-int anyfail(void)
+static int anyfail(void)
 {
 	tst_brkm(TFAIL, tst_rmdir, "Test failed\n");
 }

--- a/testcases/kernel/mem/mmapstress/mmapstress02.c
+++ b/testcases/kernel/mem/mmapstress/mmapstress02.c
@@ -55,13 +55,13 @@ static int fd;
 #define FAILED 0
 #define PASSED 1
 
-int local_flag = PASSED;
-char *TCID = "mmapstress02";	//uiomove_phys_fail
-FILE *temp;
-int TST_TOTAL = 1;
+static int local_flag = PASSED;
+static char *TCID = "mmapstress02";	//uiomove_phys_fail
+static FILE *temp;
+static int TST_TOTAL = 1;
 
-int anyfail();
-void ok_exit();
+static int anyfail();
+static void ok_exit();
 /*****  **      **      *****/
 
  /*ARGSUSED*/ static
@@ -174,14 +174,14 @@ int main(int argc, char *argv[])
 }
 
 /*****  LTP Port        *****/
-void ok_exit(void)
+static void ok_exit(void)
 {
 	tst_resm(TPASS, "Test passed\n");
 	tst_rmdir();
 	tst_exit();
 }
 
-int anyfail(void)
+static int anyfail(void)
 {
 	tst_brkm(TFAIL, tst_rmdir, "Test failed");
 }

--- a/testcases/kernel/mem/mmapstress/mmapstress03.c
+++ b/testcases/kernel/mem/mmapstress/mmapstress03.c
@@ -48,12 +48,12 @@
 #include "test.h"
 #include "tst_kernel.h"
 
-char *TCID = "mmapstress03";
-FILE *temp;
-int TST_TOTAL = 1;
+static char *TCID = "mmapstress03";
+static FILE *temp;
+static int TST_TOTAL = 1;
 
-int anyfail();
-void ok_exit();
+static int anyfail();
+static void ok_exit();
 
 #define AS_SVSM_VSEG_MAX	48UL
 #define AS_SVSM_MMAP_MAX	16UL
@@ -201,13 +201,13 @@ static void do_test(void* brk_max, long pagesize)
 	}
 }
 
-void ok_exit(void)
+static void ok_exit(void)
 {
 	tst_resm(TPASS, "Test passed");
 	tst_exit();
 }
 
-int anyfail(void)
+static int anyfail(void)
 {
 	tst_brkm(TFAIL, NULL, "Test failed");
 }

--- a/testcases/kernel/mem/mmapstress/mmapstress05.c
+++ b/testcases/kernel/mem/mmapstress/mmapstress05.c
@@ -47,13 +47,13 @@
 #define FAILED 0
 #define PASSED 1
 
-int local_flag = PASSED;
-char *TCID = "mmapstress05";	//mfile_insque
-FILE *temp;
-int TST_TOTAL = 1;
+static int local_flag = PASSED;
+static char *TCID = "mmapstress05";	//mfile_insque
+static FILE *temp;
+static int TST_TOTAL = 1;
 
-int anyfail();
-void ok_exit();
+static int anyfail();
+static void ok_exit();
 /*****	**	**	*****/
 
 #define ERROR(M)	(void)fprintf(stderr, "%s:  errno = %d; " M "\n", \
@@ -202,14 +202,14 @@ int main(int argc, char *argv[])
 	tst_exit();
 }
 
-void ok_exit(void)
+static void ok_exit(void)
 {
 	tst_resm(TPASS, "Test passed\n");
 	tst_rmdir();
 	tst_exit();
 }
 
-int anyfail(void)
+static int anyfail(void)
 {
 	tst_brkm(TFAIL, tst_rmdir, "Test failed\n");
 }

--- a/testcases/kernel/mem/mmapstress/mmapstress06.c
+++ b/testcases/kernel/mem/mmapstress/mmapstress06.c
@@ -40,13 +40,13 @@
 #define FAILED 0
 #define PASSED 1
 
-int local_flag = PASSED;
-char *TCID = "mmapstress06";	//mfile_swap
-FILE *temp;
-int TST_TOTAL = 1;
+static int local_flag = PASSED;
+static char *TCID = "mmapstress06";	//mfile_swap
+static FILE *temp;
+static int TST_TOTAL = 1;
 
-int anyfail();
-void ok_exit();
+static int anyfail();
+static void ok_exit();
 /*****	**	**	*****/
 
 #define ANON_GRAN_PAGES_MAX	(32U)
@@ -102,13 +102,13 @@ int main(int argc, char *argv[])
 }
 
 /*****	LTP Port	*****/
-void ok_exit(void)
+static void ok_exit(void)
 {
 	tst_resm(TPASS, "Test passed\n");
 	tst_exit();
 }
 
-int anyfail(void)
+static int anyfail(void)
 {
 	tst_brkm(TFAIL, NULL, "Test failed\n");
 }

--- a/testcases/kernel/mem/mmapstress/mmapstress07.c
+++ b/testcases/kernel/mem/mmapstress/mmapstress07.c
@@ -61,15 +61,15 @@ extern char *ctime(const time_t *);
 extern void exit(int);
 static int checkchars(int fd, char val, int n);
 
-char *TCID = "mmapstress07";
+static char *TCID = "mmapstress07";
 
-int local_flag = PASSED;
-int block_number;
-FILE *temp;
-int TST_TOTAL = 1;
+static int local_flag = PASSED;
+static int block_number;
+static FILE *temp;
+static int TST_TOTAL = 1;
 
-int anyfail();
-void ok_exit();
+static int anyfail();
+static void ok_exit();
 
  /*ARGSUSED*/ static
 void cleanup(int sig)
@@ -311,12 +311,12 @@ static int checkchars(int fd, char val, int n)
 }
 
 /*****	**	LTP Port	**	*****/
-int anyfail(void)
+static int anyfail(void)
 {
 	tst_brkm(TFAIL, tst_rmdir, "Test failed\n");
 }
 
-void ok_exit(void)
+static void ok_exit(void)
 {
 	tst_resm(TPASS, "Test passed\n");
 	tst_rmdir();

--- a/testcases/kernel/mem/mmapstress/mmapstress08.c
+++ b/testcases/kernel/mem/mmapstress/mmapstress08.c
@@ -36,14 +36,14 @@
 #define FAILED 0
 #define PASSED 1
 
-int local_flag = PASSED;
-char *TCID = "mmapstress08";
-FILE *temp;
-int TST_TOTAL = 1;
+static int local_flag = PASSED;
+static char *TCID = "mmapstress08";
+static FILE *temp;
+static int TST_TOTAL = 1;
 
 #if defined(__i386__) || defined(__x86_64__)
-int anyfail();
-void ok_exit();
+static int anyfail();
+static void ok_exit();
 /*****  **      **      *****/
 
 #define NPTEPG		(1024)
@@ -105,13 +105,13 @@ extern long sysconf(int name);
 }
 
 /*****  LTP Port        *****/
-void ok_exit(void)
+static void ok_exit(void)
 {
 	tst_resm(TPASS, "Test passed\n");
 	tst_exit();
 }
 
-int anyfail(void)
+static int anyfail(void)
 {
 	tst_brkm(TFAIL, NULL, "Test failed\n");
 }

--- a/testcases/kernel/mem/page/page01.c
+++ b/testcases/kernel/mem/page/page01.c
@@ -47,23 +47,23 @@ int bd_arg(char *);
 /** LTP Port **/
 #include "test.h"
 
-void blenter(void);
-void setup(void);
-void anyfail(void);
-void ok_exit(void);
-void forkfail(void);
-void terror(char *);
-int instress(void);
+static void blenter(void);
+static void setup(void);
+static void anyfail(void);
+static void ok_exit(void);
+static void forkfail(void);
+static void terror(char *);
+static int instress(void);
 
 #define FAILED 0
 #define PASSED 1
 
-int local_flag = PASSED;
-int block_number;
-FILE *temp;
+static int local_flag = PASSED;
+static int block_number;
+static FILE *temp;
 
-char *TCID = "page01";		/* Test program identifier.    */
-int TST_TOTAL = 1;		/* Total number of test cases. */
+static char *TCID = "page01";		/* Test program identifier.    */
+static int TST_TOTAL = 1;		/* Total number of test cases. */
 /**************/
 
 int main(argc, argv)
@@ -205,7 +205,7 @@ char *str;
  *
  * Do set up - here its a dummy function
  */
-void setup()
+static void setup()
 {
 	tst_tmpdir();
 	temp = stderr;
@@ -216,7 +216,7 @@ void setup()
  *
  * Description: Print message on entering a new block
  */
-void blenter()
+static void blenter()
 {
 	local_flag = PASSED;
 	return;
@@ -228,7 +228,7 @@ void blenter()
  *
  * Description: Exit a test.
  */
-void anyfail()
+static void anyfail()
 {
 	(local_flag == FAILED) ? tst_resm(TFAIL, "Test failed")
 	    : tst_resm(TPASS, "Test passed");
@@ -241,7 +241,7 @@ void anyfail()
  *
  * Calling block passed the test
  */
-void ok_exit()
+static void ok_exit()
 {
 	local_flag = PASSED;
 	return;
@@ -252,7 +252,7 @@ void ok_exit()
  *
  * exit on failure
  */
-void forkfail()
+static void forkfail()
 {
 	tst_brkm(TBROK, tst_rmdir, "Reason: %s\n", strerror(errno));
 }
@@ -264,7 +264,7 @@ void forkfail()
  *              test case failed, for example fork() failed. We will log this
  *              failure as TBROK instead of TFAIL.
  */
-void terror(char *message)
+static void terror(char *message)
 {
 	tst_resm(TBROK, "Reason: %s:%s\n", message, strerror(errno));
 	return;
@@ -276,7 +276,7 @@ void terror(char *message)
  * Assume that we are always running under stress, so this function will
  * return > 0 value always.
  */
-int instress()
+static int instress()
 {
 	tst_resm(TINFO, "System resource may be too low, fork() malloc()"
 		 " etc are likely to fail.\n");

--- a/testcases/kernel/mem/page/page02.c
+++ b/testcases/kernel/mem/page/page02.c
@@ -54,16 +54,18 @@ CALLS:	malloc(3)
 #define FAILED 0
 #define PASSED 1
 
-int local_flag = PASSED;
-int block_number;
+static int local_flag = PASSED;
+static int block_number;
 
-char *TCID = "page02";		/* Test program identifier.    */
-int TST_TOTAL = 1;		/* Total number of test cases. */
+static char *TCID = "page02";		/* Test program identifier.    */
+static int TST_TOTAL = 1;		/* Total number of test cases. */
 /**************/
 
-int bd_arg(char *);
-int chld_flag;
-int parent_pid;
+static int bd_arg(char *);
+static int chld_flag;
+static int parent_pid;
+
+static int chld();
 
 int main(argc, argv)
 int argc;
@@ -75,7 +77,6 @@ char *argv[];
 	int *memory_pointer;
 	int *up_pointer, *down_pointer;
 	int child, count;
-	int chld();
 
 	parent_pid = getpid();
 	tst_tmpdir();
@@ -221,13 +222,13 @@ char *argv[];
 
 }
 
-int bd_arg(str)
+static int bd_arg(str)
 char *str;
 {
 	tst_brkm(TCONF, NULL, "\tCannot parse %s as a number.\n", str);
 }
 
-int chld()
+static int chld()
 {
 	if (signal(SIGUSR1, (void (*)())chld) == SIG_ERR) {
 		tst_brkm(TBROK, NULL, "signal failed");

--- a/testcases/kernel/mem/tunable/min_free_kbytes.c
+++ b/testcases/kernel/mem/tunable/min_free_kbytes.c
@@ -39,7 +39,7 @@
 
 #define MAP_SIZE (1UL<<20)
 
-volatile int end;
+static volatile int end;
 static long default_tune = -1;
 static long orig_overcommit = -1;
 static unsigned long total_mem;

--- a/testcases/kernel/mem/vma/vma03.c
+++ b/testcases/kernel/mem/vma/vma03.c
@@ -53,8 +53,8 @@
 #include "tst_kernel.h"
 #include "lapi/abisize.h"
 
-char *TCID = "vma03";
-int TST_TOTAL = 1;
+static char *TCID = "vma03";
+static int TST_TOTAL = 1;
 
 #ifdef __NR_mmap2
 #define TESTFILE "testfile"

--- a/testcases/kernel/mem/vmtests/data_space.c
+++ b/testcases/kernel/mem/vmtests/data_space.c
@@ -49,11 +49,11 @@
 #define FAILED 0
 #define PASSED 1
 
-int local_flag = PASSED;
-int block_number;
+static int local_flag = PASSED;
+static int block_number;
 
-char *TCID = "data_space";	/* Test program identifier.    */
-int TST_TOTAL = 1;		/* Total number of test cases. */
+static char *TCID = "data_space";	/* Test program identifier.    */
+static int TST_TOTAL = 1;		/* Total number of test cases. */
 /**************/
 
 #define MAXCHILD	100	/* max number of children to allow */
@@ -66,31 +66,31 @@ int allchild[MAXCHILD + 1];
 	tst_brkm(TCONF, NULL, \
 	    "bad argument - %s - could not parse as number.", str)
 
-int nchild;			/* # kids */
-int csize;			/* chunk size */
-int iterations;			/* # total iterations */
-int rep_freq;			/* report frequency */
-int max_size;			/* max file size */
-int parent_pid;
+static int nchild;			/* # kids */
+static int csize;			/* chunk size */
+static int iterations;			/* # total iterations */
+static int rep_freq;			/* report frequency */
+static int max_size;			/* max file size */
+static int parent_pid;
 
-int usage(char *);
-int runtest();
-int dotest(int, int);
-void bfill(char *, char, int);
-int dumpbuf(char *);
-void dumpbits(char *, int);
-int massmurder();
-int okexit(int);
+static int usage(char *);
+static int runtest();
+static int dotest(int, int);
+static void bfill(char *, char, int);
+static int dumpbuf(char *);
+static void dumpbits(char *, int);
+static int massmurder();
+static int okexit(int);
 
-char *prog;			/* invoked name */
-int chld_flag = 0;
+static char *prog;			/* invoked name */
+static int chld_flag = 0;
 
-void cleanup(void)
+static void cleanup(void)
 {
 	tst_rmdir();
 }
 
-int usage(prog)
+static int usage(prog)
 char *prog;
 {
 	tst_resm(TCONF, "Usage: %s <nchild> <size> <chunk_size> <iterations>",
@@ -98,13 +98,14 @@ char *prog;
 	tst_brkm(TCONF, NULL, "DEFAULTS: 10 1024*1024 4096 25");
 }
 
+static int term();
+static int chld();
+
 int main(argc, argv)
 int argc;
 char *argv[];
 {
 	int i = 1;
-	int term();
-	int chld();
 
 	prog = argv[0];
 
@@ -145,7 +146,7 @@ char *argv[];
 	tst_exit();
 }
 
-int runtest()
+static int runtest()
 {
 	register int i;
 	int child;
@@ -211,11 +212,11 @@ int runtest()
  *
  */
 
-int nchunks;
+static int nchunks;
 
 #define	CHUNK(i)	((i) * csize)
 
-int dotest(testers, me)
+static int dotest(testers, me)
 int testers;
 int me;
 {
@@ -357,7 +358,7 @@ int me;
 	return 0;
 }
 
-void bfill(buf, val, size)
+static void bfill(buf, val, size)
 register char *buf;
 char val;
 register int size;
@@ -373,7 +374,7 @@ register int size;
  *	Dump the buffer.
  */
 
-int dumpbuf(buf)
+static int dumpbuf(buf)
 register char *buf;
 {
 	register int i;
@@ -425,7 +426,7 @@ register char *buf;
  *	Dump the bit-map.
  */
 
-void dumpbits(bits, size)
+static void dumpbits(bits, size)
 char *bits;
 register int size;
 {
@@ -447,7 +448,7 @@ register int size;
  *	Parent - kill kids and return when signal arrives.
  *	Child - exit.
  */
-int term()
+static int term()
 {
 #ifdef DEBUG
 	tst_resm(TINFO, "\tterm -[%d]- got sig term.\n", getpid());
@@ -461,7 +462,7 @@ int term()
 	exit(0);
 }
 
-int chld()
+static int chld()
 {
 	if (sigset(SIGUSR1, (void (*)())chld) == SIG_ERR) {
 		tst_resm(TBROK, "sigset shichld");
@@ -471,7 +472,7 @@ int chld()
 	return 0;
 }
 
-int massmurder()
+static int massmurder()
 {
 	int i;
 	for (i = 0; i < MAXCHILD; i++) {
@@ -482,7 +483,7 @@ int massmurder()
 	return 0;
 }
 
-int okexit(me)
+static int okexit(me)
 int me;
 {
 	kill(parent_pid, SIGUSR1);

--- a/testcases/kernel/mem/vmtests/stack_space.c
+++ b/testcases/kernel/mem/vmtests/stack_space.c
@@ -44,11 +44,11 @@
 #define FAILED 0
 #define PASSED 1
 
-int local_flag = PASSED;
-int block_number;
+static int local_flag = PASSED;
+static int block_number;
 
-char *TCID = "stack_space";	/* Test program identifier.    */
-int TST_TOTAL = 1;		/* Total number of test cases. */
+static char *TCID = "stack_space";	/* Test program identifier.    */
+static int TST_TOTAL = 1;		/* Total number of test cases. */
 /**************/
 
 #define MAXCHILD	100	/* max # kids */
@@ -57,33 +57,34 @@ int TST_TOTAL = 1;		/* Total number of test cases. */
 #define K_4		4096
 #define MAXSIZE         10*K_1
 
-int nchild;			/* # kids */
-int csize;			/* chunk size */
-int iterations;			/* # total iterations */
-int parent_pid;
+static int nchild;			/* # kids */
+static int csize;			/* chunk size */
+static int iterations;			/* # total iterations */
+static int parent_pid;
 
-int usage(char *);
-int bd_arg(char *);
-int runtest();
-int dotest(int, int);
-int bfill(char *, char, int);
-int dumpbuf(char *);
-void dumpbits(char *, int);
+static int usage(char *);
+static int bd_arg(char *);
+static int runtest();
+static int dotest(int, int);
+static int bfill(char *, char, int);
+static int dumpbuf(char *);
+static void dumpbits(char *, int);
 
-char *prog;			/* invoked name */
+static char *prog;			/* invoked name */
 
-int usage(char *prog)
+static int usage(char *prog)
 {
 	tst_resm(TCONF, "Usage: %s <nchild> <chunk_size> <iterations>", prog);
 	tst_brkm(TCONF, NULL, "DEFAULTS: 20 1024 50");
 }
+
+static void term();
 
 int main(argc, argv)
 int argc;
 char *argv[];
 {
 	register int i;
-	void term();
 
 	prog = argv[0];
 	parent_pid = getpid();
@@ -125,7 +126,7 @@ char *argv[];
 
 }
 
-int bd_arg(str)
+static int bd_arg(str)
 char *str;
 {
 	tst_brkm(TCONF, NULL,
@@ -133,7 +134,7 @@ char *str;
 		 str);
 }
 
-int runtest()
+static int runtest()
 {
 	register int i;
 	int child;
@@ -198,11 +199,11 @@ int runtest()
  * When fill sectors, iterate.
  */
 
-int nchunks;
+static int nchunks;
 
 #define	CHUNK(i)	((i) * csize)
 
-int dotest(int testers, int me)
+static int dotest(int testers, int me)
 {
 	char *bits;
 	char *val_buf;
@@ -324,7 +325,7 @@ int dotest(int testers, int me)
 	return 0;
 }
 
-int bfill(buf, val, size)
+static int bfill(buf, val, size)
 register char *buf;
 char val;
 register int size;
@@ -341,7 +342,7 @@ register int size;
  *	Dump the buffer.
  */
 
-int dumpbuf(buf)
+static int dumpbuf(buf)
 register char *buf;
 {
 	register int i;
@@ -394,7 +395,7 @@ register char *buf;
  *	Dump the bit-map.
  */
 
-void dumpbits(bits, size)
+static void dumpbits(bits, size)
 char *bits;
 register int size;
 {
@@ -412,7 +413,7 @@ register int size;
 
 }
 
-void term()
+static void term()
 {
 
 	if (getpid() == parent_pid) {

--- a/testcases/kernel/power_management/pm_get_sched_values.c
+++ b/testcases/kernel/power_management/pm_get_sched_values.c
@@ -17,7 +17,7 @@
 #include <stdio.h>
 #include "test.h"
 
-const char *TCID = "pm_get_sched_values";
+static const char *TCID = "pm_get_sched_values";
 
 int get_supp_sched_mc(void)
 {

--- a/testcases/kernel/sched/hyperthreading/ht_enabled/ht_enabled.c
+++ b/testcases/kernel/sched/hyperthreading/ht_enabled/ht_enabled.c
@@ -16,8 +16,8 @@
 #include "test.h"
 #include "ht_utils.h"
 
-char *TCID = "smt_smp_enabled";
-int TST_TOTAL = 1;
+static char *TCID = "smt_smp_enabled";
+static int TST_TOTAL = 1;
 
 int main(int argc, char *argv[])
 {

--- a/testcases/kernel/sched/pthreads/pth_str01.c
+++ b/testcases/kernel/sched/pthreads/pth_str01.c
@@ -55,8 +55,8 @@ int num_nodes(int, int);
 int synchronize_children(c_info *);
 int doit(c_info *);
 
-char *TCID = "pth_str01";
-int TST_TOTAL = 1;
+static char *TCID = "pth_str01";
+static int TST_TOTAL = 1;
 
 void testexit(int value)
 {

--- a/testcases/kernel/sched/pthreads/pth_str02.c
+++ b/testcases/kernel/sched/pthreads/pth_str02.c
@@ -67,10 +67,10 @@ void *thread(void *);
 
 int num_threads = DEFAULT_NUM_THREADS;
 int test_limit = 0;
-int debug = 0;
+static int debug = 0;
 
-char *TCID = "pth_str02";
-int TST_TOTAL = 1;
+static char *TCID = "pth_str02";
+static int TST_TOTAL = 1;
 
 /*---------------------------------------------------------------------+
 |                               main ()                                |

--- a/testcases/kernel/sched/pthreads/pth_str03.c
+++ b/testcases/kernel/sched/pthreads/pth_str03.c
@@ -58,26 +58,26 @@ struct kid_info {
 typedef struct kid_info c_info;
 
 /* Global variables */
-int depth = 3;
-int breadth = 4;
-int timeout = 30;		/* minutes */
-int cdepth;			/* current depth */
-int debug = 0;
+static int depth = 3;
+static int breadth = 4;
+static int timeout = 30;		/* minutes */
+static int cdepth;			/* current depth */
+static int debug = 0;
 
-c_info *child_info;		/* pointer to info array */
-int node_count;			/* number of nodes created so far */
-pthread_mutex_t node_mutex;	/* mutex for the node_count */
-pthread_cond_t node_condvar;	/* condition variable for node_count */
-pthread_attr_t attr;		/* attributes for created threads */
+static c_info *child_info;		/* pointer to info array */
+static int node_count;			/* number of nodes created so far */
+static pthread_mutex_t node_mutex;	/* mutex for the node_count */
+static pthread_cond_t node_condvar;	/* condition variable for node_count */
+static pthread_attr_t attr;		/* attributes for created threads */
 
-int num_nodes(int, int);
-int synchronize_children(c_info *);
-void *doit(void *);
+static int num_nodes(int, int);
+static int synchronize_children(c_info *);
+static void *doit(void *);
 
-char *TCID = "pth_str03";
-int TST_TOTAL = 1;
+static char *TCID = "pth_str03";
+static int TST_TOTAL = 1;
 
-void testexit(int value)
+static void testexit(int value)
 {
 	if (value == 0)
 		tst_resm(TPASS, "Test passed");
@@ -160,7 +160,7 @@ static void parse_args(int argc, char *argv[])
  *
  * Caculate the number of child nodes for a given breadth and depth tree.
  *--------------------------------------------------------------------------------*/
-int num_nodes(int b, int d)
+static int num_nodes(int b, int d)
 {
 	int n, sum = 1, partial_exp = 1;
 
@@ -185,7 +185,7 @@ int num_nodes(int b, int d)
  * Register the child with the parent and then wait for all of the children
  * at the same level to register also.  Return when everything is synched up.
  *--------------------------------------------------------------------------------*/
-int synchronize_children(c_info * parent)
+static int synchronize_children(c_info * parent)
 {
 	int my_index, rc;
 	c_info *info_p;
@@ -319,7 +319,7 @@ int synchronize_children(c_info * parent)
  *
  * Do it.
  *--------------------------------------------------------------------------------*/
-void *doit(void *param)
+static void *doit(void *param)
 {
 	c_info *parent = (c_info *) param;
 	int rc, child, my_index;

--- a/testcases/kernel/sched/sched_stress/sched_tc0.c
+++ b/testcases/kernel/sched/sched_stress/sched_tc0.c
@@ -72,8 +72,8 @@
  *
  * parse_args: parse command line arguments
  */
-void process_file(char *);
-void parse_args(int, char **);
+static void process_file(char *);
+static void parse_args(int, char **);
 
 /*
  * Global variables:
@@ -170,7 +170,7 @@ int main(int argc, char **argv)
 |            end-of-file and then closes the file..                    |
 |                                                                      |
 +---------------------------------------------------------------------*/
-void process_file(char *filename)
+static void process_file(char *filename)
 {
 	char record[100];	/* holds each record of the file read */
 	FILE *datafile;		/* file pointer to the open file */
@@ -211,7 +211,7 @@ void process_file(char *filename)
 |            [-d]           enable debugging messages                  |
 |                                                                      |
 +---------------------------------------------------------------------*/
-void parse_args(int argc, char **argv)
+static void parse_args(int argc, char **argv)
 {
 	int opt;
 	int pflg = 0, tflg = 0;

--- a/testcases/kernel/sched/sched_stress/sched_tc1.c
+++ b/testcases/kernel/sched/sched_stress/sched_tc1.c
@@ -69,9 +69,9 @@
  *
  * parse_args: parse command line arguments
  */
-void process_file(char *);
-void parse_args(int, char **);
-void signal_handler();
+static void process_file(char *);
+static void parse_args(int, char **);
+static void signal_handler();
 
 /*
  * Global variables:
@@ -84,10 +84,10 @@ void signal_handler();
  *
  * priority: process type (fixed priority, variable priority)
  */
-int verbose = 0;
-int debug = 0;
-int signaled = 0;
-char *priority = DEFAULT_PRIORITY_TYPE;
+static int verbose = 0;
+static int debug = 0;
+static int signaled = 0;
+static char *priority = DEFAULT_PRIORITY_TYPE;
 
 /*---------------------------------------------------------------------+
 |                                 main                                 |
@@ -157,7 +157,7 @@ int main(int argc, char **argv)
 |            end-of-file and then closes the file..                    |
 |                                                                      |
 +---------------------------------------------------------------------*/
-void process_file(char *filename)
+static void process_file(char *filename)
 {
 	char record[100];	/* holds each record of the file read */
 	FILE *datafile;		/* file pointer to the open file */
@@ -190,7 +190,7 @@ void process_file(char *filename)
 | Function:  ...                                                       |
 |                                                                      |
 +---------------------------------------------------------------------*/
-void signal_handler(int signal)
+static void signal_handler(int signal)
 {
 	printf("signal received is %d\n", signal);
 	if (signal == SIGUSR1) {
@@ -219,7 +219,7 @@ void signal_handler(int signal)
 |            [-d]           enable debugging messages                  |
 |                                                                      |
 +---------------------------------------------------------------------*/
-void parse_args(int argc, char **argv)
+static void parse_args(int argc, char **argv)
 {
 	int opt;
 	int pflg = 0;

--- a/testcases/kernel/sched/sched_stress/sched_tc2.c
+++ b/testcases/kernel/sched/sched_stress/sched_tc2.c
@@ -76,8 +76,8 @@
  *
  * parse_args: parse command line arguments
  */
-void parse_args(int, char **);
-void multiply_matrices();
+static void parse_args(int, char **);
+static void multiply_matrices();
 
 /*
  * Global variables:
@@ -90,10 +90,10 @@ void multiply_matrices();
  *
  * priority: process type (fixed priority, variable priority)
  */
-int verbose = 0;
-int debug = 0;
-long execution_time = DEFAULT_EXECUTION_TIME;
-char *priority = DEFAULT_PRIORITY_TYPE;
+static int verbose = 0;
+static int debug = 0;
+static long execution_time = DEFAULT_EXECUTION_TIME;
+static char *priority = DEFAULT_PRIORITY_TYPE;
 
 /*---------------------------------------------------------------------+
 |                                 main                                 |
@@ -172,7 +172,7 @@ int main(int argc, char **argv)
 |            them together.                                            |
 |                                                                      |
 +---------------------------------------------------------------------*/
-void multiply_matrices()
+static void multiply_matrices()
 {
 	int i, j, k;		/* various indeces to access the arrays */
 	float matrix_1[MATRIX_SIZE][MATRIX_SIZE];
@@ -216,7 +216,7 @@ void multiply_matrices()
 |            [-d]           enable debugging messages                  |
 |                                                                      |
 +---------------------------------------------------------------------*/
-void parse_args(int argc, char **argv)
+static void parse_args(int argc, char **argv)
 {
 	int opt;
 	int pflg = 0, tflg = 0;

--- a/testcases/kernel/sched/sched_stress/sched_tc3.c
+++ b/testcases/kernel/sched/sched_stress/sched_tc3.c
@@ -76,9 +76,9 @@
  *
  * parse_args: parse command line arguments
  */
-void parse_args(int, char **);
-void multiply_matrices();
-void signal_handler();
+static void parse_args(int, char **);
+static void multiply_matrices();
+static void signal_handler();
 
 /*
  * Global variables:
@@ -91,10 +91,10 @@ void signal_handler();
  *
  * priority: process type (fixed priority, variable priority)
  */
-int verbose = 0;
-int debug = 0;
-int signaled = 0;
-char *priority = DEFAULT_PRIORITY_TYPE;
+static int verbose = 0;
+static int debug = 0;
+static int signaled = 0;
+static char *priority = DEFAULT_PRIORITY_TYPE;
 
 /*---------------------------------------------------------------------+
 |                                 main                                 |
@@ -175,7 +175,7 @@ int main(int argc, char **argv)
 |            them together.                                            |
 |                                                                      |
 +---------------------------------------------------------------------*/
-void multiply_matrices()
+static void multiply_matrices()
 {
 	int i, j, k;		/* various indeces to access the arrays */
 	float matrix_1[MATRIX_SIZE][MATRIX_SIZE];
@@ -211,7 +211,7 @@ void multiply_matrices()
 | Function:  ...                                                       |
 |                                                                      |
 +---------------------------------------------------------------------*/
-void signal_handler(int signal)
+static void signal_handler(int signal)
 {
 	if (signal == SIGUSR1) {
 		signaled++;
@@ -239,7 +239,7 @@ void signal_handler(int signal)
 |            [-d]           enable debugging messages                  |
 |                                                                      |
 +---------------------------------------------------------------------*/
-void parse_args(int argc, char **argv)
+static void parse_args(int argc, char **argv)
 {
 	int opt;
 	int pflg = 0;

--- a/testcases/kernel/sched/sched_stress/sched_tc4.c
+++ b/testcases/kernel/sched/sched_stress/sched_tc4.c
@@ -82,7 +82,7 @@
  *
  * parse_args: parse command line arguments
  */
-void parse_args(int, char **);
+static void parse_args(int, char **);
 void read_raw_device();
 
 /*
@@ -94,11 +94,11 @@ void read_raw_device();
  *
  * priority: process type (fixed priority, variable priority)
  */
-int verbose = 0;
-int debug = 0;
-int priority = DEFAULT_PRIORITY;
-char *logfile = DEFAULT_LOGFILE;
-char *priority_type = DEFAULT_PRIORITY_TYPE;
+static int verbose = 0;
+static int debug = 0;
+static int priority = DEFAULT_PRIORITY;
+static char *logfile = DEFAULT_LOGFILE;
+static char *priority_type = DEFAULT_PRIORITY_TYPE;
 
 /*---------------------------------------------------------------------+
 |                                 main                                 |
@@ -240,7 +240,7 @@ void read_raw_device()
 |            [-d]           enable debugging messages                  |
 |                                                                      |
 +---------------------------------------------------------------------*/
-void parse_args(int argc, char **argv)
+static void parse_args(int argc, char **argv)
 {
 	int opt;
 	int lflg = 0, pflg = 0, tflg = 0;

--- a/testcases/kernel/sched/sched_stress/sched_tc5.c
+++ b/testcases/kernel/sched/sched_stress/sched_tc5.c
@@ -78,8 +78,8 @@
  *
  * parse_args: parse command line arguments
  */
-void parse_args(int, char **);
-void invert_matrix();
+static void parse_args(int, char **);
+static void invert_matrix();
 
 /*
  * Global variables:
@@ -90,11 +90,11 @@ void invert_matrix();
  *
  * priority: process type (fixed priority, variable priority)
  */
-int verbose = 0;
-int debug = 0;
-int priority = DEFAULT_PRIORITY;
-char *logfile = DEFAULT_LOGFILE;
-char *priority_type = DEFAULT_PRIORITY_TYPE;
+static int verbose = 0;
+static int debug = 0;
+static int priority = DEFAULT_PRIORITY;
+static char *logfile = DEFAULT_LOGFILE;
+static char *priority_type = DEFAULT_PRIORITY_TYPE;
 
 /*---------------------------------------------------------------------+
 |                                 main                                 |
@@ -177,7 +177,7 @@ int main(int argc, char **argv)
 |               inverse..                                              |
 |                                                                      |
 +---------------------------------------------------------------------*/
-void invert_matrix()
+static void invert_matrix()
 {
 	int i, j, k;
 	float t1;
@@ -243,7 +243,7 @@ void invert_matrix()
 |            [-d]           enable debugging messages                  |
 |                                                                      |
 +---------------------------------------------------------------------*/
-void parse_args(int argc, char **argv)
+static void parse_args(int argc, char **argv)
 {
 	int opt;
 	int lflg = 0, pflg = 0, tflg = 0;

--- a/testcases/kernel/security/cap_bound/cap_bset_inh_bounds.c
+++ b/testcases/kernel/security/cap_bound/cap_bset_inh_bounds.c
@@ -35,8 +35,8 @@
 #include <sys/prctl.h>
 #include "test.h"
 
-char *TCID = "cap_bounds_r";
-int TST_TOTAL = 2;
+static char *TCID = "cap_bounds_r";
+static int TST_TOTAL = 2;
 
 int main(int argc, char *argv[])
 {

--- a/testcases/kernel/security/cap_bound/check_pe.c
+++ b/testcases/kernel/security/cap_bound/check_pe.c
@@ -36,8 +36,8 @@
 #include <sys/prctl.h>
 #include "test.h"
 
-char *TCID = "check_pe";
-int TST_TOTAL = 1;
+static char *TCID = "check_pe";
+static int TST_TOTAL = 1;
 
 int main(int argc, char *argv[])
 {

--- a/testcases/kernel/security/dirtyc0w/dirtyc0w_child.c
+++ b/testcases/kernel/security/dirtyc0w/dirtyc0w_child.c
@@ -71,7 +71,7 @@ void *proc_self_mem_thread(void *arg)
 	return NULL;
 }
 
-void sighandler(int sig)
+static void sighandler(int sig)
 {
 	(void) sig;
 

--- a/testcases/kernel/security/filecaps/inh_capped.c
+++ b/testcases/kernel/security/filecaps/inh_capped.c
@@ -32,8 +32,8 @@
 #endif
 #include "test.h"
 
-char *TCID = "filecaps";
-int TST_TOTAL = 1;
+static char *TCID = "filecaps";
+static int TST_TOTAL = 1;
 
 #ifdef HAVE_LIBCAP
 void debug_print_caps(char *when)

--- a/testcases/kernel/security/prot_hsymlinks/prot_hsymlinks.c
+++ b/testcases/kernel/security/prot_hsymlinks/prot_hsymlinks.c
@@ -45,8 +45,8 @@
 #include "test.h"
 #include "safe_macros.h"
 
-char *TCID = "prot_hsymlinks";
-int TST_TOTAL = 396;
+static char *TCID = "prot_hsymlinks";
+static int TST_TOTAL = 396;
 
 /* create 3 files and 1 dir in each base dir */
 #define MAX_FILES_CREATED	4

--- a/testcases/kernel/security/securebits/check_keepcaps.c
+++ b/testcases/kernel/security/securebits/check_keepcaps.c
@@ -25,8 +25,8 @@
    TODO: all of the other securebits tests.
  */
 
-char *TCID = "keepcaps";
-int TST_TOTAL = 1;
+static char *TCID = "keepcaps";
+static int TST_TOTAL = 1;
 
 #if (HAVE_LINUX_SECUREBITS_H && HAVE_LIBCAP)
 #include <linux/securebits.h>

--- a/testcases/kernel/syscalls/chdir/chdir02.c
+++ b/testcases/kernel/syscalls/chdir/chdir02.c
@@ -114,11 +114,11 @@
 #include <signal.h>
 #include "test.h"
 
-void setup();
-void cleanup();
+static void setup();
+static void cleanup();
 
-char *TCID = "chdir02";
-int TST_TOTAL = 1;
+static char *TCID = "chdir02";
+static int TST_TOTAL = 1;
 
 char *dirs[2] = { "/", "/tmp" };
 
@@ -150,7 +150,7 @@ int main(int ac, char **av)
 	tst_exit();
 }
 
-void setup(void)
+static void setup(void)
 {
 
 	tst_sig(NOFORK, DEF_HANDLER, cleanup);
@@ -158,6 +158,6 @@ void setup(void)
 	TEST_PAUSE;
 }
 
-void cleanup(void)
+static void cleanup(void)
 {
 }

--- a/testcases/kernel/syscalls/chdir/chdir03.c
+++ b/testcases/kernel/syscalls/chdir/chdir03.c
@@ -49,7 +49,7 @@ void verify_chdir(void)
 	}
 }
 
-void setup(void)
+static void setup(void)
 {
 	struct passwd *pw;
 

--- a/testcases/kernel/syscalls/chmod/chmod02.c
+++ b/testcases/kernel/syscalls/chmod/chmod02.c
@@ -50,8 +50,8 @@
 
 static int modes[] = { 0, 07, 070, 0700, 0777, 02777, 04777, 06777 };
 
-char *TCID = "chmod02";
-int TST_TOTAL = ARRAY_SIZE(modes);
+static char *TCID = "chmod02";
+static int TST_TOTAL = ARRAY_SIZE(modes);
 
 #define FNAME "test_file"
 

--- a/testcases/kernel/syscalls/chmod/chmod04.c
+++ b/testcases/kernel/syscalls/chmod/chmod04.c
@@ -89,13 +89,13 @@
 				 */
 #define TESTDIR		"testdir_4"
 
-char *TCID = "chmod04";
-int TST_TOTAL = 1;
-char nobody_uid[] = "nobody";
-struct passwd *ltpuser;
+static char *TCID = "chmod04";
+static int TST_TOTAL = 1;
+static char nobody_uid[] = "nobody";
+static struct passwd *ltpuser;
 
-void setup();
-void cleanup();
+static void setup();
+static void cleanup();
 
 int main(int ac, char **av)
 {
@@ -156,7 +156,7 @@ int main(int ac, char **av)
  *  Create a temporary directory and cd to it.
  *  Create another test directory under temporary directory.
  */
-void setup(void)
+static void setup(void)
 {
 
 	tst_sig(NOFORK, DEF_HANDLER, cleanup);
@@ -183,7 +183,7 @@ void setup(void)
  *		completion or premature exit.
  *  Remove the test directory and temporary directory created in setup().
  */
-void cleanup(void)
+static void cleanup(void)
 {
 
 	tst_rmdir();

--- a/testcases/kernel/syscalls/chmod/chmod06.c
+++ b/testcases/kernel/syscalls/chmod/chmod06.c
@@ -67,7 +67,7 @@ static struct tcase {
 
 static char *bad_addr;
 
-void run(unsigned int i)
+static void run(unsigned int i)
 {
 	if (tc[i].setup)
 		tc[i].setup();
@@ -91,17 +91,17 @@ void run(unsigned int i)
 	}
 }
 
-void set_root(void)
+static void set_root(void)
 {
 	SAFE_SETEUID(0);
 }
 
-void set_nobody(void)
+static void set_nobody(void)
 {
 	SAFE_SETEUID(nobody_uid);
 }
 
-void setup(void)
+static void setup(void)
 {
 	struct passwd *nobody;
 	unsigned int i;

--- a/testcases/kernel/syscalls/chmod/chmod07.c
+++ b/testcases/kernel/syscalls/chmod/chmod07.c
@@ -35,7 +35,7 @@
 #define PERMS		01777	/* Permissions with sticky bit set. */
 #define TESTFILE	"testfile"
 
-void test_chmod(void)
+static void test_chmod(void)
 {
 	struct stat stat_buf;
 
@@ -63,7 +63,7 @@ void test_chmod(void)
 	}
 }
 
-void setup(void)
+static void setup(void)
 {
 	struct passwd *ltpuser;
 	struct group *ltpgroup;

--- a/testcases/kernel/syscalls/chown/chown01.c
+++ b/testcases/kernel/syscalls/chown/chown01.c
@@ -119,7 +119,7 @@
 #include "compat_16.h"
 
 TCID_DEFINE(chown01);
-int TST_TOTAL = 1;
+static int TST_TOTAL = 1;
 
 char fname[255];
 int uid, gid;

--- a/testcases/kernel/syscalls/chown/chown02.c
+++ b/testcases/kernel/syscalls/chown/chown02.c
@@ -90,10 +90,10 @@
 
 TCID_DEFINE(chown02);
 
-int setup1();			/* Test specific setup functions */
-int setup2();
+static int setup1();			/* Test specific setup functions */
+static int setup2();
 
-struct test_case_t {
+static struct test_case_t {
 	char *pathname;
 	uid_t user_id;
 	gid_t group_id;
@@ -107,10 +107,10 @@ struct test_case_t {
 	{
 TESTFILE2, 700, 701, 2, setup2},};
 
-int TST_TOTAL = ARRAY_SIZE(test_cases);
+static int TST_TOTAL = ARRAY_SIZE(test_cases);
 
-void setup();			/* setup function for the test */
-void cleanup();			/* cleanup function for the test */
+static void setup();			/* setup function for the test */
+static void cleanup();			/* cleanup function for the test */
 
 int main(int ac, char **av)
 {
@@ -207,7 +207,7 @@ int main(int ac, char **av)
  *  Create a temporary directory and change directory to it.
  *  Create a test file under temporary directory and close it
  */
-void setup(void)
+static void setup(void)
 {
 	int i;
 
@@ -230,7 +230,7 @@ void setup(void)
  *	      set on an executable file will not be cleared.
  *  Creat a testfile and set setuid/setgid bits on the mode of file.$
  */
-int setup1(void)
+static int setup1(void)
 {
 	int fd;			/* File descriptor for testfile1 */
 
@@ -252,7 +252,7 @@ int setup1(void)
  *	      set on non-group executable file will not be cleared.
  *  Creat a testfile and set setgid bit on the mode of file.
  */
-int setup2(void)
+static int setup2(void)
 {
 	int fd;			/* File descriptor for testfile2 */
 
@@ -275,7 +275,7 @@ int setup2(void)
  *	       completion or premature exit.
  *  Remove the test directory and testfile created in the setup.
  */
-void cleanup(void)
+static void cleanup(void)
 {
 
 	tst_rmdir();

--- a/testcases/kernel/syscalls/chown/chown03.c
+++ b/testcases/kernel/syscalls/chown/chown03.c
@@ -89,12 +89,12 @@
 #define TESTFILE	"testfile"
 
 TCID_DEFINE(chown03);
-int TST_TOTAL = 1;		/* Total number of test conditions */
-char nobody_uid[] = "nobody";
-struct passwd *ltpuser;
+static int TST_TOTAL = 1;		/* Total number of test conditions */
+static char nobody_uid[] = "nobody";
+static struct passwd *ltpuser;
 
-void setup();			/* setup function for the test */
-void cleanup();			/* cleanup function for the test */
+static void setup();			/* setup function for the test */
+static void cleanup();			/* cleanup function for the test */
 
 int main(int ac, char **av)
 {
@@ -155,7 +155,7 @@ int main(int ac, char **av)
  *  Create a test file under temporary directory and close it
  *  Change the group ownership on testfile.
  */
-void setup(void)
+static void setup(void)
 {
 	int fd;			/* file handler for testfile */
 
@@ -190,7 +190,7 @@ void setup(void)
 	SAFE_CLOSE(cleanup, fd);
 }
 
-void cleanup(void)
+static void cleanup(void)
 {
 	if (setegid(0) == -1)
 		tst_resm(TWARN | TERRNO, "setegid(0) failed");

--- a/testcases/kernel/syscalls/chown/chown04.c
+++ b/testcases/kernel/syscalls/chown/chown04.c
@@ -86,7 +86,7 @@ static struct test_case_t {
 };
 
 TCID_DEFINE(chown04);
-int TST_TOTAL = ARRAY_SIZE(tc);
+static int TST_TOTAL = ARRAY_SIZE(tc);
 
 static char *bad_addr;
 

--- a/testcases/kernel/syscalls/clock_nanosleep/clock_nanosleep01.c
+++ b/testcases/kernel/syscalls/clock_nanosleep/clock_nanosleep01.c
@@ -99,7 +99,7 @@ static struct test_variants {
 #endif
 };
 
-void setup(void)
+static void setup(void)
 {
 	rq->type = variants[tst_variant].type;
 	tst_res(TINFO, "Testing variant: %s", variants[tst_variant].desc);

--- a/testcases/kernel/syscalls/clock_nanosleep/clock_nanosleep02.c
+++ b/testcases/kernel/syscalls/clock_nanosleep/clock_nanosleep02.c
@@ -12,7 +12,7 @@
 #include <errno.h>
 #include "tst_timer_test.h"
 
-int sample_fn(int clk_id, long long usec)
+static int sample_fn(int clk_id, long long usec)
 {
 	struct timespec t = tst_timespec_from_us(usec);
 

--- a/testcases/kernel/syscalls/clock_nanosleep/clock_nanosleep04.c
+++ b/testcases/kernel/syscalls/clock_nanosleep/clock_nanosleep04.c
@@ -32,7 +32,7 @@ static struct test_variants {
 #endif
 };
 
-void setup(void)
+static void setup(void)
 {
 	tst_res(TINFO, "Testing variant: %s", variants[tst_variant].desc);
 }

--- a/testcases/kernel/syscalls/close/close01.c
+++ b/testcases/kernel/syscalls/close/close01.c
@@ -29,17 +29,17 @@
 #include "test.h"
 #include "safe_macros.h"
 
-void cleanup(void);
-void setup(void);
+static void cleanup(void);
+static void setup(void);
 
-char *TCID = "close01";
-int TST_TOTAL = 2;
+static char *TCID = "close01";
+static int TST_TOTAL = 2;
 
-char fname[40] = "";
+static char fname[40] = "";
 
-int fild, newfd, pipefildes[2];
+static int fild, newfd, pipefildes[2];
 
-struct test_case_t {
+static struct test_case_t {
 	int *fd;
 	char *type;
 } TC[] = {
@@ -99,7 +99,7 @@ int main(int ac, char **av)
 	tst_exit();
 }
 
-void setup(void)
+static void setup(void)
 {
 	int mypid;
 
@@ -115,7 +115,7 @@ void setup(void)
 	sprintf(fname, "fname.%d", mypid);
 }
 
-void cleanup(void)
+static void cleanup(void)
 {
 	close(fild);
 

--- a/testcases/kernel/syscalls/close/close08.c
+++ b/testcases/kernel/syscalls/close/close08.c
@@ -117,14 +117,14 @@
 #include "test.h"
 #include "safe_macros.h"
 
-void setup();
-void cleanup();
+static void setup();
+static void cleanup();
 
-char *TCID = "close08";
-int TST_TOTAL = 1;
+static char *TCID = "close08";
+static int TST_TOTAL = 1;
 
-char fname[255];
-int fd;
+static char fname[255];
+static int fd;
 
 int main(int ac, char **av)
 {
@@ -158,7 +158,7 @@ int main(int ac, char **av)
 	tst_exit();
 }
 
-void setup(void)
+static void setup(void)
 {
 
 	tst_sig(NOFORK, DEF_HANDLER, cleanup);
@@ -170,7 +170,7 @@ void setup(void)
 	sprintf(fname, "tfile_%d", getpid());
 }
 
-void cleanup(void)
+static void cleanup(void)
 {
 	tst_rmdir();
 

--- a/testcases/kernel/syscalls/cma/process_vm01.c
+++ b/testcases/kernel/syscalls/cma/process_vm01.c
@@ -67,8 +67,8 @@ static option_t options[] = {
 
 static char TCID_readv[] = "process_vm_readv";
 static char TCID_writev[] = "process_vm_writev";
-char *TCID = "cma01";
-int TST_TOTAL = 1;
+static char *TCID = "cma01";
+static int TST_TOTAL = 1;
 static void (*cma_test_params) (struct process_vm_params * params) = NULL;
 
 static void setup(char *argv[]);

--- a/testcases/kernel/syscalls/cma/process_vm_readv02.c
+++ b/testcases/kernel/syscalls/cma/process_vm_readv02.c
@@ -31,8 +31,8 @@
 #include "safe_macros.h"
 #include "lapi/syscalls.h"
 
-char *TCID = "process_vm_readv02";
-int TST_TOTAL = 1;
+static char *TCID = "process_vm_readv02";
+static int TST_TOTAL = 1;
 
 static char *tst_string = "THIS IS A TEST";
 static int len;

--- a/testcases/kernel/syscalls/cma/process_vm_readv03.c
+++ b/testcases/kernel/syscalls/cma/process_vm_readv03.c
@@ -34,8 +34,8 @@
 #include "safe_macros.h"
 #include "lapi/syscalls.h"
 
-char *TCID = "process_vm_readv03";
-int TST_TOTAL = 1;
+static char *TCID = "process_vm_readv03";
+static int TST_TOTAL = 1;
 
 #define NUM_LOCAL_VECS 4
 

--- a/testcases/kernel/syscalls/cma/process_vm_writev02.c
+++ b/testcases/kernel/syscalls/cma/process_vm_writev02.c
@@ -32,8 +32,8 @@
 #include "safe_macros.h"
 #include "lapi/syscalls.h"
 
-char *TCID = "process_vm_writev02";
-int TST_TOTAL = 1;
+static char *TCID = "process_vm_writev02";
+static int TST_TOTAL = 1;
 
 #define PADDING_SIZE 10
 #define DEFAULT_CHAR 53

--- a/testcases/kernel/syscalls/creat/creat08.c
+++ b/testcases/kernel/syscalls/creat/creat08.c
@@ -54,9 +54,9 @@
 #include "test.h"
 #include "safe_macros.h"
 
-char *TCID = "creat08";
-int TST_TOTAL = 1;
-int local_flag;
+static char *TCID = "creat08";
+static int TST_TOTAL = 1;
+static int local_flag;
 
 #define PASSED 1
 #define FAILED 0

--- a/testcases/kernel/syscalls/dup/dup01.c
+++ b/testcases/kernel/syscalls/dup/dup01.c
@@ -117,14 +117,14 @@
 #include "test.h"
 #include "safe_macros.h"
 
-void setup();
-void cleanup();
+static void setup();
+static void cleanup();
 
-char *TCID = "dup01";
-int TST_TOTAL = 1;
+static char *TCID = "dup01";
+static int TST_TOTAL = 1;
 
-char filename[255];
-int fd;
+static char filename[255];
+static int fd;
 
 int main(int ac, char **av)
 {
@@ -161,7 +161,7 @@ int main(int ac, char **av)
 	tst_exit();
 }
 
-void setup(void)
+static void setup(void)
 {
 	fd = -1;
 
@@ -176,7 +176,7 @@ void setup(void)
 		tst_brkm(TBROK | TERRNO, cleanup, "open failed");
 }
 
-void cleanup(void)
+static void cleanup(void)
 {
 	if (fd != -1)
 		if (close(fd) == -1)

--- a/testcases/kernel/syscalls/dup/dup02.c
+++ b/testcases/kernel/syscalls/dup/dup02.c
@@ -116,11 +116,11 @@
 #include "test.h"
 #include "safe_macros.h"
 
-void setup();
-void cleanup();
+static void setup();
+static void cleanup();
 
-char *TCID = "dup02";
-int TST_TOTAL = 2;
+static char *TCID = "dup02";
+static int TST_TOTAL = 2;
 
 int Fds[] = { -1, 1500 };
 
@@ -162,7 +162,7 @@ int main(int ac, char **av)
 	tst_exit();
 }
 
-void setup(void)
+static void setup(void)
 {
 
 	tst_sig(FORK, DEF_HANDLER, cleanup);
@@ -173,7 +173,7 @@ void setup(void)
 
 }
 
-void cleanup(void)
+static void cleanup(void)
 {
 	tst_rmdir();
 }

--- a/testcases/kernel/syscalls/dup/dup03.c
+++ b/testcases/kernel/syscalls/dup/dup03.c
@@ -114,15 +114,15 @@
 #include "test.h"
 #include "safe_macros.h"
 
-void setup();
-void cleanup();
+static void setup();
+static void cleanup();
 
-char *TCID = "dup03";
-int TST_TOTAL = 1;
+static char *TCID = "dup03";
+static int TST_TOTAL = 1;
 
-char filename[255];
-int *fd = NULL;
-int nfds = 0;
+static char filename[255];
+static int *fd = NULL;
+static int nfds = 0;
 
 int main(int ac, char **av)
 {
@@ -158,7 +158,7 @@ int main(int ac, char **av)
 	tst_exit();
 }
 
-void setup(void)
+static void setup(void)
 {
 	long maxfds;
 
@@ -201,7 +201,7 @@ void setup(void)
 			 "tried %ld", maxfds);
 }
 
-void cleanup(void)
+static void cleanup(void)
 {
 	int i;
 

--- a/testcases/kernel/syscalls/dup/dup04.c
+++ b/testcases/kernel/syscalls/dup/dup04.c
@@ -121,13 +121,13 @@
 #include "test.h"
 #include "safe_macros.h"
 
-void setup();
-void cleanup();
+static void setup();
+static void cleanup();
 
-char *TCID = "dup04";
-int TST_TOTAL = 2;
+static char *TCID = "dup04";
+static int TST_TOTAL = 2;
 
-int fd[2];
+static int fd[2];
 
 int main(int ac, char **av)
 {
@@ -174,7 +174,7 @@ int main(int ac, char **av)
 	tst_exit();
 }
 
-void setup(void)
+static void setup(void)
 {
 	fd[0] = -1;
 
@@ -187,7 +187,7 @@ void setup(void)
 	SAFE_PIPE(cleanup, fd);
 }
 
-void cleanup(void)
+static void cleanup(void)
 {
 	int i;
 

--- a/testcases/kernel/syscalls/dup/dup05.c
+++ b/testcases/kernel/syscalls/dup/dup05.c
@@ -118,14 +118,14 @@
 #include "test.h"
 #include "safe_macros.h"
 
-void setup();
-void cleanup();
+static void setup();
+static void cleanup();
 
-char *TCID = "dup05";
-int TST_TOTAL = 1;
+static char *TCID = "dup05";
+static int TST_TOTAL = 1;
 
-char Fname[255];
-int fd;
+static char Fname[255];
+static int fd;
 
 int main(int ac, char **av)
 {
@@ -156,7 +156,7 @@ int main(int ac, char **av)
 	tst_exit();
 }
 
-void setup(void)
+static void setup(void)
 {
 	fd = -1;
 
@@ -172,7 +172,7 @@ void setup(void)
 		tst_brkm(TBROK, cleanup, "open failed");
 }
 
-void cleanup(void)
+static void cleanup(void)
 {
 	if (fd != -1)
 		if (close(fd) == -1)

--- a/testcases/kernel/syscalls/dup/dup06.c
+++ b/testcases/kernel/syscalls/dup/dup06.c
@@ -34,8 +34,8 @@
 #include <sys/param.h>
 #include "test.h"
 
-char *TCID = "dup06";
-int TST_TOTAL = 1;
+static char *TCID = "dup06";
+static int TST_TOTAL = 1;
 
 static int cnt_free_fds(int maxfd)
 {

--- a/testcases/kernel/syscalls/dup/dup07.c
+++ b/testcases/kernel/syscalls/dup/dup07.c
@@ -36,8 +36,8 @@
 #include <sys/stat.h>
 #include "test.h"
 
-char *TCID = "dup07";
-int TST_TOTAL = 3;
+static char *TCID = "dup07";
+static int TST_TOTAL = 3;
 
 static const char *testfile = "dup07";
 

--- a/testcases/kernel/syscalls/dup2/dup202.c
+++ b/testcases/kernel/syscalls/dup2/dup202.c
@@ -55,20 +55,20 @@
 #include "test.h"
 #include "safe_macros.h"
 
-char *TCID = "dup202";
-int TST_TOTAL = 3;
+static char *TCID = "dup202";
+static int TST_TOTAL = 3;
 
-void setup(void);
-void cleanup(void);
+static void setup(void);
+static void cleanup(void);
 
-char testfile[40];
-int fail;
-int newfd;
+static char testfile[40];
+static int fail;
+static int newfd;
 
 /* set these to a known index into our local file descriptor table */
-int duprdo = 10, dupwro = 20, duprdwr = 30;
+static int duprdo = 10, dupwro = 20, duprdwr = 30;
 
-struct test_case_t {
+static struct test_case_t {
 	int *nfd;
 	mode_t mode;
 } TC[] = {
@@ -143,7 +143,7 @@ int main(int ac, char **av)
 /*
  * setup() - performs all ONE TIME setup for this test.
  */
-void setup(void)
+static void setup(void)
 {
 
 	tst_sig(NOFORK, DEF_HANDLER, cleanup);
@@ -161,7 +161,7 @@ void setup(void)
  * cleanup() - performs all ONE TIME cleanup for this test at
  *	       completion or premature exit.
  */
-void cleanup(void)
+static void cleanup(void)
 {
 	tst_rmdir();
 }

--- a/testcases/kernel/syscalls/dup2/dup203.c
+++ b/testcases/kernel/syscalls/dup2/dup203.c
@@ -51,11 +51,11 @@
 #include "test.h"
 #include "safe_macros.h"
 
-void setup(void);
-void cleanup(void);
+static void setup(void);
+static void cleanup(void);
 
-char *TCID = "dup203";
-int TST_TOTAL = 1;
+static char *TCID = "dup203";
+static int TST_TOTAL = 1;
 
 int main(int ac, char **av)
 {
@@ -188,7 +188,7 @@ int main(int ac, char **av)
 /*
  * setup() - performs all ONE TIME setup for this test.
  */
-void setup(void)
+static void setup(void)
 {
 
 	tst_sig(NOFORK, DEF_HANDLER, cleanup);
@@ -202,7 +202,7 @@ void setup(void)
  * cleanup() - performs all ONE TIME cleanup for this test at
  *	       completion or premature exit.
  */
-void cleanup(void)
+static void cleanup(void)
 {
 	tst_rmdir();
 }

--- a/testcases/kernel/syscalls/dup2/dup204.c
+++ b/testcases/kernel/syscalls/dup2/dup204.c
@@ -52,13 +52,13 @@
 #include "test.h"
 #include "safe_macros.h"
 
-void setup();
-void cleanup();
+static void setup();
+static void cleanup();
 
-char *TCID = "dup204";
-int TST_TOTAL = 2;
+static char *TCID = "dup204";
+static int TST_TOTAL = 2;
 
-int fd[2];
+static int fd[2];
 int nfd[2];
 
 int main(int ac, char **av)
@@ -102,7 +102,7 @@ int main(int ac, char **av)
 	tst_exit();
 }
 
-void setup(void)
+static void setup(void)
 {
 	fd[0] = -1;
 
@@ -115,7 +115,7 @@ void setup(void)
 	SAFE_PIPE(cleanup, fd);
 }
 
-void cleanup(void)
+static void cleanup(void)
 {
 	int i;
 

--- a/testcases/kernel/syscalls/dup2/dup205.c
+++ b/testcases/kernel/syscalls/dup2/dup205.c
@@ -38,11 +38,11 @@
 #include <unistd.h>
 #include "test.h"
 
-char *TCID = "dup205";
-int TST_TOTAL = 1;
-int *fildes;
-int min;
-int local_flag;
+static char *TCID = "dup205";
+static int TST_TOTAL = 1;
+static int *fildes;
+static int min;
+static int local_flag;
 
 #define PASSED 1
 #define FAILED 0

--- a/testcases/kernel/syscalls/dup3/dup3_02.c
+++ b/testcases/kernel/syscalls/dup3/dup3_02.c
@@ -57,8 +57,8 @@ static struct test_case_t {
 	{&old_fd, &new_fd, INVALID_FLAG, EINVAL}
 };
 
-char *TCID = "dup3_02";
-int TST_TOTAL = ARRAY_SIZE(test_cases);
+static char *TCID = "dup3_02";
+static int TST_TOTAL = ARRAY_SIZE(test_cases);
 
 int main(int ac, char **av)
 {

--- a/testcases/kernel/syscalls/epoll/epoll-ltp.c
+++ b/testcases/kernel/syscalls/epoll/epoll-ltp.c
@@ -98,8 +98,8 @@
 #include "config.h"
 #include "test.h"
 
-char *TCID = "epoll01";
-int TST_TOTAL = 1;
+static char *TCID = "epoll01";
+static int TST_TOTAL = 1;
 
 #ifdef HAVE_SYS_EPOLL_H
 

--- a/testcases/kernel/syscalls/epoll_pwait/epoll_pwait01.c
+++ b/testcases/kernel/syscalls/epoll_pwait/epoll_pwait01.c
@@ -37,8 +37,8 @@
 #include "epoll_pwait.h"
 #include "safe_macros.h"
 
-char *TCID = "epoll_pwait01";
-int TST_TOTAL = 2;
+static char *TCID = "epoll_pwait01";
+static int TST_TOTAL = 2;
 
 static int epfd, fds[2];
 static sigset_t signalset;

--- a/testcases/kernel/syscalls/epoll_wait/epoll_wait02.c
+++ b/testcases/kernel/syscalls/epoll_wait/epoll_wait02.c
@@ -20,7 +20,7 @@ static struct epoll_event epevs[1] = {
        {.events = EPOLLIN}
 };
 
-int sample_fn(int clk_id, long long usec)
+static int sample_fn(int clk_id, long long usec)
 {
 	unsigned int sleep_ms = usec / 1000;
 

--- a/testcases/kernel/syscalls/epoll_wait/epoll_wait03.c
+++ b/testcases/kernel/syscalls/epoll_wait/epoll_wait03.c
@@ -69,8 +69,8 @@ static struct test_case_t {
 	{&epfd, &ev_rdonly, 1, EFAULT}
 };
 
-char *TCID = "epoll_wait03";
-int TST_TOTAL = ARRAY_SIZE(tc);
+static char *TCID = "epoll_wait03";
+static int TST_TOTAL = ARRAY_SIZE(tc);
 
 static void setup(void);
 static void verify_epoll_wait(struct test_case_t *tc);

--- a/testcases/kernel/syscalls/eventfd2/eventfd2_03.c
+++ b/testcases/kernel/syscalls/eventfd2/eventfd2_03.c
@@ -38,15 +38,15 @@
 #include "test.h"
 #include "lapi/syscalls.h"
 
-char *TCID = "eventfd2_03";
-int TST_TOTAL = 1;
+static char *TCID = "eventfd2_03";
+static int TST_TOTAL = 1;
 
 #ifndef EFD_SEMLIKE
 #define EFD_SEMLIKE (1 << 0)
 #endif
 
 /* Dummy function as syscall from linux_syscall_numbers.h uses cleanup(). */
-void cleanup(void)
+static void cleanup(void)
 {
 }
 

--- a/testcases/kernel/syscalls/exit/exit01.c
+++ b/testcases/kernel/syscalls/exit/exit01.c
@@ -32,8 +32,8 @@
 static void cleanup(void);
 static void setup(void);
 
-char *TCID = "exit01";
-int TST_TOTAL = 1;
+static char *TCID = "exit01";
+static int TST_TOTAL = 1;
 
 int main(int ac, char **av)
 {

--- a/testcases/kernel/syscalls/exit_group/exit_group01.c
+++ b/testcases/kernel/syscalls/exit_group/exit_group01.c
@@ -28,9 +28,9 @@
 #include "safe_macros.h"
 #include "lapi/syscalls.h"
 
-char *TCID = "exit_group01";
-int testno;
-int TST_TOTAL = 1;
+static char *TCID = "exit_group01";
+static int testno;
+static int TST_TOTAL = 1;
 
 static void verify_exit_group(void)
 {

--- a/testcases/kernel/syscalls/faccessat/faccessat01.c
+++ b/testcases/kernel/syscalls/faccessat/faccessat01.c
@@ -49,11 +49,11 @@
 #ifndef AT_FDCWD
 #define AT_FDCWD -100
 #endif
-void setup();
-void cleanup();
+static void setup();
+static void cleanup();
 
-char *TCID = "faccessat01";
-int TST_TOTAL = TEST_CASES;
+static char *TCID = "faccessat01";
+static int TST_TOTAL = TEST_CASES;
 static char pathname[256];
 static char testfile[256];
 static char testfile2[256];
@@ -62,7 +62,7 @@ static int fds[TEST_CASES];
 static char *filenames[TEST_CASES];
 static int expected_errno[TEST_CASES] = { 0, 0, ENOTDIR, EBADF, 0, 0 };
 
-int myfaccessat(int dirfd, const char *filename, int mode)
+static int myfaccessat(int dirfd, const char *filename, int mode)
 {
 	return ltp_syscall(__NR_faccessat, dirfd, filename, mode);
 }
@@ -107,7 +107,7 @@ int main(int ac, char **av)
 	tst_exit();
 }
 
-void setup(void)
+static void setup(void)
 {
 	tst_sig(NOFORK, DEF_HANDLER, cleanup);
 
@@ -144,7 +144,7 @@ void setup(void)
 	TEST_PAUSE;
 }
 
-void cleanup(void)
+static void cleanup(void)
 {
 	if (fds[0] > 0)
 		close(fds[0]);

--- a/testcases/kernel/syscalls/fchdir/fchdir01.c
+++ b/testcases/kernel/syscalls/fchdir/fchdir01.c
@@ -63,22 +63,23 @@
 #include <libgen.h>
 #include <string.h>
 
-void cleanup(void);
-void setup(void);
+static void cleanup(void);
+static void setup(void);
 
-char *TCID = "fchdir01";
-int TST_TOTAL = 1;
+static char *TCID = "fchdir01";
+static int TST_TOTAL = 1;
 
-int fd;
-char *temp_dir;
+static int fd;
+static char *temp_dir;
 const char *TEST_DIR = "alpha";
 
 #define MODES	S_IRWXU
 
+static void check_functionality(void);
+
 int main(int ac, char **av)
 {
 	int lc;
-	void check_functionality(void);
 	int r_val;
 
 	tst_parse_opts(ac, av, NULL, NULL);
@@ -137,7 +138,7 @@ int main(int ac, char **av)
 	tst_exit();
 }
 
-void check_functionality(void)
+static void check_functionality(void)
 {
 	char *buf = NULL;
 	char *dir;
@@ -155,7 +156,7 @@ void check_functionality(void)
 		tst_resm(TFAIL, "fchdir call failed");
 }
 
-void setup(void)
+static void setup(void)
 {
 
 	tst_sig(NOFORK, DEF_HANDLER, cleanup);
@@ -165,7 +166,7 @@ void setup(void)
 	tst_tmpdir();
 }
 
-void cleanup(void)
+static void cleanup(void)
 {
 	tst_rmdir();
 }

--- a/testcases/kernel/syscalls/fchdir/fchdir03.c
+++ b/testcases/kernel/syscalls/fchdir/fchdir03.c
@@ -42,7 +42,7 @@ void verify_fchdir(void)
 	tst_res(TPASS | TTERRNO, "fchdir() failed expectedly");
 }
 
-void setup(void)
+static void setup(void)
 {
 	struct passwd *pw;
 

--- a/testcases/kernel/syscalls/fchmod/fchmod03.c
+++ b/testcases/kernel/syscalls/fchmod/fchmod03.c
@@ -83,15 +83,15 @@
 #include "safe_macros.h"
 #include "fchmod.h"
 
-int fd;				/* file descriptor for test file */
-char *TCID = "fchmod03";
-int TST_TOTAL = 1;
+static int fd;				/* file descriptor for test file */
+static char *TCID = "fchmod03";
+static int TST_TOTAL = 1;
 
-char nobody_uid[] = "nobody";
-struct passwd *ltpuser;
+static char nobody_uid[] = "nobody";
+static struct passwd *ltpuser;
 
-void setup();			/* Main setup function for the test */
-void cleanup();			/* Main cleanup function for the test */
+static void setup();			/* Main setup function for the test */
+static void cleanup();			/* Main cleanup function for the test */
 
 int main(int ac, char **av)
 {
@@ -135,7 +135,7 @@ int main(int ac, char **av)
 	tst_exit();
 }
 
-void setup(void)
+static void setup(void)
 {
 
 	tst_sig(NOFORK, DEF_HANDLER, cleanup);
@@ -160,7 +160,7 @@ void setup(void)
 		tst_brkm(TBROK | TERRNO, cleanup, "open failed");
 }
 
-void cleanup(void)
+static void cleanup(void)
 {
 	if (close(fd) == -1)
 		tst_resm(TWARN | TERRNO, "close failed");

--- a/testcases/kernel/syscalls/fchmod/fchmod04.c
+++ b/testcases/kernel/syscalls/fchmod/fchmod04.c
@@ -83,15 +83,15 @@
 #include "safe_macros.h"
 #include "fchmod.h"
 
-int fd;				/* file descriptor for test directory */
-char *TCID = "fchmod04";
-int TST_TOTAL = 1;
+static int fd;				/* file descriptor for test directory */
+static char *TCID = "fchmod04";
+static int TST_TOTAL = 1;
 
-char nobody_uid[] = "nobody";
-struct passwd *ltpuser;
+static char nobody_uid[] = "nobody";
+static struct passwd *ltpuser;
 
-void setup();
-void cleanup();
+static void setup();
+static void cleanup();
 
 int main(int ac, char **av)
 {
@@ -142,7 +142,7 @@ int main(int ac, char **av)
  *  Create another test directory under temporary directory.
  *  Open the test directory for reading.
  */
-void setup(void)
+static void setup(void)
 {
 	tst_require_root();
 
@@ -179,7 +179,7 @@ void setup(void)
  *  Close the test directory opened during setup().
  *  Remove the test directory and temporary directory created in setup().
  */
-void cleanup(void)
+static void cleanup(void)
 {
 
 	/* Close the test directory opened during setup() */

--- a/testcases/kernel/syscalls/fchmodat/fchmodat01.c
+++ b/testcases/kernel/syscalls/fchmodat/fchmodat01.c
@@ -49,11 +49,11 @@
 #ifndef AT_FDCWD
 #define AT_FDCWD -100
 #endif
-void setup();
-void cleanup();
+static void setup();
+static void cleanup();
 
-char *TCID = "fchmodat01";
-int TST_TOTAL = TEST_CASES;
+static char *TCID = "fchmodat01";
+static int TST_TOTAL = TEST_CASES;
 char pathname[256];
 char testfile[256];
 char testfile2[256];
@@ -105,7 +105,7 @@ int main(int ac, char **av)
 	tst_exit();
 }
 
-void setup(void)
+static void setup(void)
 {
 	tst_sig(NOFORK, DEF_HANDLER, cleanup);
 
@@ -141,7 +141,7 @@ void setup(void)
 	TEST_PAUSE;
 }
 
-void cleanup(void)
+static void cleanup(void)
 {
 	if (fds[0] > 0)
 		close(fds[0]);

--- a/testcases/kernel/syscalls/fchown/fchown01.c
+++ b/testcases/kernel/syscalls/fchown/fchown01.c
@@ -47,7 +47,7 @@ static void setup(void);
 static void cleanup(void);
 
 TCID_DEFINE(fchown01);
-int TST_TOTAL = 1;
+static int TST_TOTAL = 1;
 
 static int fd;
 

--- a/testcases/kernel/syscalls/fchown/fchown02.c
+++ b/testcases/kernel/syscalls/fchown/fchown02.c
@@ -47,11 +47,11 @@
 #define TESTFILE2	"testfile2"
 
 TCID_DEFINE(fchown02);
-int TST_TOTAL = 2;
+static int TST_TOTAL = 2;
 static int fd1;
 static int fd2;
 
-struct test_case {
+static struct test_case {
 	int *fd;
 	char *pathname;
 	char *desc;

--- a/testcases/kernel/syscalls/fchown/fchown03.c
+++ b/testcases/kernel/syscalls/fchown/fchown03.c
@@ -48,7 +48,7 @@
 #define TESTFILE	"testfile"
 
 TCID_DEFINE(fchown03);
-int TST_TOTAL = 1;
+static int TST_TOTAL = 1;
 
 static int fildes;
 char nobody_uid[] = "nobody";

--- a/testcases/kernel/syscalls/fchown/fchown04.c
+++ b/testcases/kernel/syscalls/fchown/fchown04.c
@@ -65,7 +65,7 @@ static struct test_case_t {
 };
 
 TCID_DEFINE(fchown04);
-int TST_TOTAL = ARRAY_SIZE(test_cases);
+static int TST_TOTAL = ARRAY_SIZE(test_cases);
 
 static void setup(void);
 static void fchown_verify(int);

--- a/testcases/kernel/syscalls/fchown/fchown05.c
+++ b/testcases/kernel/syscalls/fchown/fchown05.c
@@ -53,7 +53,7 @@ static struct test_case_t {
 	{NULL, 0, 0}
 };
 
-int TST_TOTAL = ARRAY_SIZE(tc);
+static int TST_TOTAL = ARRAY_SIZE(tc);
 
 static void setup(void);
 static void cleanup(void);

--- a/testcases/kernel/syscalls/fchownat/fchownat01.c
+++ b/testcases/kernel/syscalls/fchownat/fchownat01.c
@@ -62,8 +62,8 @@ static struct test_case_t {
 	{0, 0, 0, &cu_fd, TESTFILE},
 };
 
-char *TCID = "fchownat01";
-int TST_TOTAL = ARRAY_SIZE(test_cases);
+static char *TCID = "fchownat01";
+static int TST_TOTAL = ARRAY_SIZE(test_cases);
 static void fchownat_verify(const struct test_case_t *);
 
 int main(int ac, char **av)

--- a/testcases/kernel/syscalls/fchownat/fchownat02.c
+++ b/testcases/kernel/syscalls/fchownat/fchownat02.c
@@ -38,8 +38,8 @@
 #define TESTFILE	"testfile"
 #define TESTFILE_LINK	"testfile_link"
 
-char *TCID = "fchownat02";
-int TST_TOTAL = 1;
+static char *TCID = "fchownat02";
+static int TST_TOTAL = 1;
 
 static int dir_fd;
 static uid_t set_uid = 1000;

--- a/testcases/kernel/syscalls/fcntl/fcntl01.c
+++ b/testcases/kernel/syscalls/fcntl/fcntl01.c
@@ -35,11 +35,11 @@
 #include <sys/stat.h>
 #include "test.h"
 
-void setup(void);
-void cleanup(void);
+static void setup(void);
+static void cleanup(void);
 
-char *TCID = "fcntl01";
-int TST_TOTAL = 1;
+static char *TCID = "fcntl01";
+static int TST_TOTAL = 1;
 
 int main(int ac, char **av)
 {

--- a/testcases/kernel/syscalls/fcntl/fcntl05.c
+++ b/testcases/kernel/syscalls/fcntl/fcntl05.c
@@ -118,15 +118,15 @@
 #include <signal.h>
 #include "test.h"
 
-void setup();
-void cleanup();
+static void setup();
+static void cleanup();
 
-char *TCID = "fcntl05";
-int TST_TOTAL = 1;
+static char *TCID = "fcntl05";
+static int TST_TOTAL = 1;
 
-char fname[255];
-int fd;
-struct flock flocks;
+static char fname[255];
+static int fd;
+static struct flock flocks;
 
 int main(int ac, char **av)
 {
@@ -156,7 +156,7 @@ int main(int ac, char **av)
 	tst_exit();
 }
 
-void setup(void)
+static void setup(void)
 {
 
 	tst_sig(NOFORK, DEF_HANDLER, cleanup);
@@ -176,7 +176,7 @@ void setup(void)
 	flocks.l_pid = getpid();
 }
 
-void cleanup(void)
+static void cleanup(void)
 {
 	if (close(fd) == -1)
 		tst_resm(TWARN | TERRNO, "close failed");

--- a/testcases/kernel/syscalls/fcntl/fcntl06.c
+++ b/testcases/kernel/syscalls/fcntl/fcntl06.c
@@ -56,18 +56,18 @@
 #define F_RGETLK 10		/* kludge code */
 #define F_RSETLK 11		/* kludge code */
 
-char *TCID = "fcntl06";
-int TST_TOTAL = 1;
+static char *TCID = "fcntl06";
+static int TST_TOTAL = 1;
 
-void setup();
-void cleanup();
+static void setup();
+static void cleanup();
 
 #define STRINGSIZE	27
 #define	STRING		"abcdefghijklmnopqrstuvwxyz\n"
 
-int fd;
-void unlock_file();
-int do_lock(int, short, short, int, int);
+static int fd;
+static void unlock_file();
+static int do_lock(int, short, short, int, int);
 
 int main(int ac, char **av)
 {
@@ -113,7 +113,7 @@ int main(int ac, char **av)
 	tst_exit();
 }
 
-void setup(void)
+static void setup(void)
 {
 	char *buf = STRING;
 	char template[PATH_MAX];
@@ -135,7 +135,7 @@ void setup(void)
 		tst_resm(TBROK | TERRNO, "write failed");
 }
 
-int do_lock(int cmd, short type, short whence, int start, int len)
+static int do_lock(int cmd, short type, short whence, int start, int len)
 {
 	struct flock fl;
 
@@ -146,7 +146,7 @@ int do_lock(int cmd, short type, short whence, int start, int len)
 	return (fcntl(fd, cmd, &fl));
 }
 
-void unlock_file(void)
+static void unlock_file(void)
 {
 	if (do_lock(F_RSETLK, (short)F_UNLCK, (short)0, 0, 0) == -1) {
 		/* Same as FIXME comment above. */
@@ -154,7 +154,7 @@ void unlock_file(void)
 	}
 }
 
-void cleanup(void)
+static void cleanup(void)
 {
 
 	if (close(fd) == -1)

--- a/testcases/kernel/syscalls/fcntl/fcntl08.c
+++ b/testcases/kernel/syscalls/fcntl/fcntl08.c
@@ -47,8 +47,8 @@
 static void setup(void);
 static void cleanup(void);
 
-char *TCID = "fcntl08";
-int TST_TOTAL = 1;
+static char *TCID = "fcntl08";
+static int TST_TOTAL = 1;
 
 static int fd;
 

--- a/testcases/kernel/syscalls/fcntl/fcntl09.c
+++ b/testcases/kernel/syscalls/fcntl/fcntl09.c
@@ -118,15 +118,15 @@
 #include <signal.h>
 #include "test.h"
 
-void setup();
-void cleanup();
+static void setup();
+static void cleanup();
 
-char *TCID = "fcntl09";
-int TST_TOTAL = 2;
+static char *TCID = "fcntl09";
+static int TST_TOTAL = 2;
 
-char fname[255];
-int fd;
-struct flock flocks;
+static char fname[255];
+static int fd;
+static struct flock flocks;
 
 int main(int ac, char **av)
 {
@@ -201,7 +201,7 @@ int main(int ac, char **av)
 /***************************************************************
  * setup() - performs all ONE TIME setup for this test.
  ***************************************************************/
-void setup(void)
+static void setup(void)
 {
 
 	tst_sig(NOFORK, DEF_HANDLER, cleanup);
@@ -233,7 +233,7 @@ void setup(void)
  * cleanup() - performs all ONE TIME cleanup for this test at
  *		completion or premature exit.
  ***************************************************************/
-void cleanup(void)
+static void cleanup(void)
 {
 
 	if (close(fd) == -1) {

--- a/testcases/kernel/syscalls/fcntl/fcntl10.c
+++ b/testcases/kernel/syscalls/fcntl/fcntl10.c
@@ -118,15 +118,15 @@
 #include <signal.h>
 #include "test.h"
 
-void setup();
-void cleanup();
+static void setup();
+static void cleanup();
 
-char *TCID = "fcntl10";
-int TST_TOTAL = 2;
+static char *TCID = "fcntl10";
+static int TST_TOTAL = 2;
 
-char fname[255];
-int fd;
-struct flock flocks;
+static char fname[255];
+static int fd;
+static struct flock flocks;
 
 int main(int ac, char **av)
 {
@@ -200,7 +200,7 @@ int main(int ac, char **av)
 /***************************************************************
  * setup() - performs all ONE TIME setup for this test.
  ***************************************************************/
-void setup(void)
+static void setup(void)
 {
 
 	tst_sig(NOFORK, DEF_HANDLER, cleanup);
@@ -234,7 +234,7 @@ void setup(void)
  * cleanup() - performs all ONE TIME cleanup for this test at
  *		completion or premature exit.
  ***************************************************************/
-void cleanup(void)
+static void cleanup(void)
 {
 
 	if (close(fd) == -1) {

--- a/testcases/kernel/syscalls/fcntl/fcntl11.c
+++ b/testcases/kernel/syscalls/fcntl/fcntl11.c
@@ -51,35 +51,35 @@
 #define STRING		"abcdefghijklmnopqrstuvwxyz\n"
 #define STOP		0xFFF0
 
-int parent_pipe[2];
-int child_pipe[2];
-int fd;
-pid_t parent_pid, child_pid;
+static int parent_pipe[2];
+static int child_pipe[2];
+static int fd;
+static pid_t parent_pid, child_pid;
 
-void parent_put();
-void parent_get();
-void child_put();
-void child_get();
-void stop_child();
-void compare_lock(struct flock *, short, short, int, int, pid_t);
-void unlock_file();
-void do_test(struct flock *, short, short, int, int);
-void catch_child();
-char *str_type();
-int do_lock(int, short, short, int, int);
+static void parent_put();
+static void parent_get();
+static void child_put();
+static void child_get();
+static void stop_child();
+static void compare_lock(struct flock *, short, short, int, int, pid_t);
+static void unlock_file();
+static void do_test(struct flock *, short, short, int, int);
+static void catch_child();
+static char *str_type();
+static int do_lock(int, short, short, int, int);
 
-char *TCID = "fcntl11";
-int TST_TOTAL = 1;
+static char *TCID = "fcntl11";
+static int TST_TOTAL = 1;
 
-int fail;
+static int fail;
 
-void cleanup(void)
+static void cleanup(void)
 {
 	tst_rmdir();
 
 }
 
-void setup(void)
+static void setup(void)
 {
 	char *buf = STRING;
 	char template[PATH_MAX];
@@ -111,7 +111,7 @@ void setup(void)
 			 "sigaction(SIGCHLD, ..) failed");
 }
 
-void do_child(void)
+static void do_child(void)
 {
 	struct flock fl;
 
@@ -125,7 +125,7 @@ void do_child(void)
 	}
 }
 
-int do_lock(int cmd, short type, short whence, int start, int len)
+static int do_lock(int cmd, short type, short whence, int start, int len)
 {
 	struct flock fl;
 
@@ -136,7 +136,7 @@ int do_lock(int cmd, short type, short whence, int start, int len)
 	return (fcntl(fd, cmd, &fl));
 }
 
-void do_test(struct flock *fl, short type, short whence, int start, int len)
+static void do_test(struct flock *fl, short type, short whence, int start, int len)
 {
 	fl->l_type = type;
 	fl->l_whence = whence;
@@ -148,7 +148,7 @@ void do_test(struct flock *fl, short type, short whence, int start, int len)
 	parent_get(fl);
 }
 
-void
+static void
 compare_lock(struct flock *fl, short type, short whence, int start, int len,
 	     pid_t pid)
 {
@@ -174,7 +174,7 @@ compare_lock(struct flock *fl, short type, short whence, int start, int len,
 			 pid, fl->l_pid);
 }
 
-void unlock_file(void)
+static void unlock_file(void)
 {
 	struct flock fl;
 
@@ -184,7 +184,7 @@ void unlock_file(void)
 	compare_lock(&fl, (short)F_UNLCK, (short)0, 0, 0, (pid_t) 0);
 }
 
-char *str_type(int type)
+static char *str_type(int type)
 {
 	static char buf[20];
 
@@ -201,29 +201,29 @@ char *str_type(int type)
 	}
 }
 
-void parent_put(struct flock *l)
+static void parent_put(struct flock *l)
 {
 	SAFE_WRITE(cleanup, 1, parent_pipe[1], l, sizeof(*l));
 }
 
-void parent_get(struct flock *l)
+static void parent_get(struct flock *l)
 {
 	SAFE_READ(cleanup, 1, child_pipe[0], l, sizeof(*l));
 }
 
-void child_put(struct flock *l)
+static void child_put(struct flock *l)
 {
 	SAFE_WRITE(NULL, 1, child_pipe[1], l, sizeof(*l));
 }
 
-void child_get(struct flock *l)
+static void child_get(struct flock *l)
 {
 	SAFE_READ(NULL, 1, parent_pipe[0], l, sizeof(*l));
 	if (l->l_type == (short)STOP)
 		exit(0);
 }
 
-void stop_child(void)
+static void stop_child(void)
 {
 	struct flock fl;
 
@@ -233,7 +233,7 @@ void stop_child(void)
 	wait(0);
 }
 
-void catch_child(void)
+static void catch_child(void)
 {
 	tst_brkm(TFAIL, cleanup, "Unexpected death of child process");
 }

--- a/testcases/kernel/syscalls/fcntl/fcntl12.c
+++ b/testcases/kernel/syscalls/fcntl/fcntl12.c
@@ -45,13 +45,13 @@
 #include <errno.h>
 #include "test.h"
 
-char *TCID = "fcntl12";
-int TST_TOTAL = 1;
+static char *TCID = "fcntl12";
+static int TST_TOTAL = 1;
 
-int fail;
-char fname[20];
-void setup(void);
-void cleanup(void);
+static int fail;
+static char fname[20];
+static void setup(void);
+static void cleanup(void);
 
 int main(int ac, char **av)
 {
@@ -103,7 +103,7 @@ int main(int ac, char **av)
 	tst_exit();
 }
 
-void setup(void)
+static void setup(void)
 {
 	tst_sig(FORK, DEF_HANDLER, cleanup);
 
@@ -113,7 +113,7 @@ void setup(void)
 	tst_tmpdir();
 }
 
-void cleanup(void)
+static void cleanup(void)
 {
 	unlink(fname);
 	tst_rmdir();

--- a/testcases/kernel/syscalls/fcntl/fcntl13.c
+++ b/testcases/kernel/syscalls/fcntl/fcntl13.c
@@ -40,10 +40,10 @@
 
 #define F_BADCMD 99999
 
-char *TCID = "fcntl13";
-int TST_TOTAL = 1;
+static char *TCID = "fcntl13";
+static int TST_TOTAL = 1;
 
-void setup(void);
+static void setup(void);
 
 int main(int ac, char **av)
 {
@@ -119,7 +119,7 @@ int main(int ac, char **av)
 	tst_exit();
 }
 
-void setup(void)
+static void setup(void)
 {
 	tst_sig(NOFORK, DEF_HANDLER, NULL);
 

--- a/testcases/kernel/syscalls/fcntl/fcntl14.c
+++ b/testcases/kernel/syscalls/fcntl/fcntl14.c
@@ -540,23 +540,23 @@ static char tmpname[40];
 
 #define FILEDATA	"ten bytes!"
 
-void catch1(int sig);
-void catch_alarm(int sig);
+static void catch1(int sig);
+static void catch_alarm(int sig);
 
-char *TCID = "fcntl14";
-int TST_TOTAL = 1;
-int NO_NFS = 1;
+static char *TCID = "fcntl14";
+static int TST_TOTAL = 1;
+static int NO_NFS = 1;
 
 #ifdef UCLINUX
 static char *argv0;
 #endif
 
-void cleanup(void)
+static void cleanup(void)
 {
 	tst_rmdir();
 }
 
-void setup(void)
+static void setup(void)
 {
 	struct sigaction act;
 
@@ -590,7 +590,7 @@ void setup(void)
 	}
 }
 
-void wake_parent(void)
+static void wake_parent(void)
 {
 	if ((kill(parent, SIGUSR1)) < 0) {
 		tst_resm(TFAIL, "Attempt to send signal to parent " "failed");
@@ -599,14 +599,14 @@ void wake_parent(void)
 	}
 }
 
-void do_usleep_child(void)
+static void do_usleep_child(void)
 {
 	usleep(100000);		/* XXX how long is long enough? */
 	wake_parent();
 	exit(0);
 }
 
-void dochild(void)
+static void dochild(void)
 {
 	int rc;
 	pid_t pid;
@@ -774,7 +774,7 @@ void dochild(void)
 	}
 }
 
-void run_test(int file_flag, int file_mode, int seek, int start, int end)
+static void run_test(int file_flag, int file_mode, int seek, int start, int end)
 {
 	fail = 0;
 
@@ -899,7 +899,7 @@ void run_test(int file_flag, int file_mode, int seek, int start, int end)
 	unlink(tmpname);
 }
 
-void catch_alarm(int sig)
+static void catch_alarm(int sig)
 {
 	/*
 	 * Timer has runout and child has not signaled, need
@@ -914,7 +914,7 @@ void catch_alarm(int sig)
 	}
 }
 
-void catch1(int sig)
+static void catch1(int sig)
 {
 	struct sigaction act;
 

--- a/testcases/kernel/syscalls/fcntl/fcntl15.c
+++ b/testcases/kernel/syscalls/fcntl/fcntl15.c
@@ -65,20 +65,20 @@
 #define	OPEN	1
 #define	FORK_	2
 
-char *TCID = "fcntl15";
-int TST_TOTAL = 1;
+static char *TCID = "fcntl15";
+static int TST_TOTAL = 1;
 
 static int parent, child1, child2, status;
 static volatile sig_atomic_t parent_flag, child_flag, alarm_flag;
 static char tmpname[40];
-struct flock flock;
+static struct flock flock;
 
 #ifdef UCLINUX
 static char *argv0;		/* set by main, passed to self_exec */
 #endif
 
 
-void alarm_sig(int sig)
+static void alarm_sig(int sig)
 {
 	signal(SIGALRM, alarm_sig);
 	alarm_flag = 1;
@@ -89,19 +89,19 @@ void alarm_sig(int sig)
 	}
 }
 
-void child_sig(int sig)
+static void child_sig(int sig)
 {
 	signal(SIGUSR1, child_sig);
 	child_flag++;
 }
 
-void parent_sig(int sig)
+static void parent_sig(int sig)
 {
 	signal(SIGUSR2, parent_sig);
 	parent_flag++;
 }
 
-int dochild1(int file_flag, int file_mode)
+static int dochild1(int file_flag, int file_mode)
 {
 	int fd_B;
 	sigset_t newmask, zeromask, oldmask;
@@ -181,7 +181,7 @@ void dochild2_uc(void)
 }
 #endif
 
-int dofork(int file_flag, int file_mode)
+static int dofork(int file_flag, int file_mode)
 {
 	/* create child process */
 	if ((child1 = FORK_OR_VFORK()) < 0) {
@@ -238,7 +238,7 @@ int dofork(int file_flag, int file_mode)
 	return 0;
 }
 
-int dochild2(int file_flag, int file_mode, int dup_flag)
+static int dochild2(int file_flag, int file_mode, int dup_flag)
 {
 	int fd_C;
 	sigset_t newmask, zeromask, oldmask;
@@ -349,14 +349,14 @@ int dochild2(int file_flag, int file_mode, int dup_flag)
 	exit(0);
 }
 
-void setup(void)
+static void setup(void)
 {
 	tst_sig(FORK, DEF_HANDLER, NULL);
 
 	TEST_PAUSE;
 }
 
-int run_test(int file_flag, int file_mode, int dup_flag)
+static int run_test(int file_flag, int file_mode, int dup_flag)
 {
 	int fd_A, fd_B;
 	fd_B = -1;

--- a/testcases/kernel/syscalls/fcntl/fcntl16.c
+++ b/testcases/kernel/syscalls/fcntl/fcntl16.c
@@ -274,10 +274,10 @@ static char tmpname[40];
 
 #define	FILEDATA	"tenbytes!"
 
-extern void catch_int(int sig);	/* signal catching subroutine */
+static void catch_int(int sig);	/* signal catching subroutine */
 
-char *TCID = "fcntl16";
-int TST_TOTAL = 1;
+static char *TCID = "fcntl16";
+static int TST_TOTAL = 1;
 
 #ifdef UCLINUX
 static char *argv0;
@@ -287,13 +287,13 @@ static char *argv0;
  * cleanup - performs all the ONE TIME cleanup for this test at completion or
  *	premature exit
  */
-void cleanup(void)
+static void cleanup(void)
 {
 	tst_rmdir();
 
 }
 
-void dochild(int kid)
+static void dochild(int kid)
 {
 	/* child process */
 	struct sigaction sact;
@@ -348,12 +348,12 @@ void dochild_uc(void)
 }
 #endif
 
-void catch_alarm(int sig)
+static void catch_alarm(int sig)
 {
 	alarm_flag = 1;
 }
 
-void catch_usr1(int sig)
+static void catch_usr1(int sig)
 {				/* invoked on catching SIGUSR1 */
 	/*
 	 * Set flag to let parent know that child #1 is ready to have the
@@ -362,7 +362,7 @@ void catch_usr1(int sig)
 	child_flag1 = 1;
 }
 
-void catch_usr2(int sig)
+static void catch_usr2(int sig)
 {				/* invoked on catching SIGUSR2 */
 	/*
 	 * Set flag to let parent know that child #2 is ready to have the
@@ -371,7 +371,7 @@ void catch_usr2(int sig)
 	child_flag2 = 1;
 }
 
-void catch_int(int sig)
+static void catch_int(int sig)
 {				/* invoked on child catching SIGUSR1 */
 	/*
 	 * Set flag to interrupt fcntl call in child and force a controlled
@@ -380,7 +380,7 @@ void catch_int(int sig)
 	parent_flag = 1;
 }
 
-void child_sig(int sig, int nkids)
+static void child_sig(int sig, int nkids)
 {
 	int i;
 
@@ -397,7 +397,7 @@ void child_sig(int sig, int nkids)
 /*
  * setup - performs all ONE TIME steup for this test
  */
-void setup(void)
+static void setup(void)
 {
 	struct sigaction sact;
 
@@ -441,7 +441,7 @@ void setup(void)
 	sigaction(SIGALRM, &sact, NULL);
 }
 
-int run_test(int file_flag, int file_mode, int start, int end)
+static int run_test(int file_flag, int file_mode, int start, int end)
 {
 	int child_count;
 	int child;

--- a/testcases/kernel/syscalls/fcntl/fcntl17.c
+++ b/testcases/kernel/syscalls/fcntl/fcntl17.c
@@ -55,8 +55,8 @@
 
 #include "test.h"
 
-char *TCID = "fcntl17";
-int TST_TOTAL = 1;
+static char *TCID = "fcntl17";
+static int TST_TOTAL = 1;
 
 #define STRINGSIZE	27
 #define STRING		"abcdefghijklmnopqrstuvwxyz\n"
@@ -64,37 +64,37 @@ int TST_TOTAL = 1;
 #define TIME_OUT	10
 
 /* global variables */
-int parent_pipe[2];
-int child_pipe1[2];
-int child_pipe2[2];
-int child_pipe3[2];
-int file_fd;
-pid_t parent_pid, child_pid1, child_pid2, child_pid3;
-int child_stat;
-struct flock lock1 = { (short)F_WRLCK, (short)0, 2, 5, (short)0 };
-struct flock lock2 = { (short)F_WRLCK, (short)0, 9, 5, (short)0 };
-struct flock lock3 = { (short)F_WRLCK, (short)0, 17, 5, (short)0 };
-struct flock lock4 = { (short)F_WRLCK, (short)0, 17, 5, (short)0 };
-struct flock lock5 = { (short)F_WRLCK, (short)0, 2, 14, (short)0 };
-struct flock unlock = { (short)F_UNLCK, (short)0, 0, 0, (short)0 };
+static int parent_pipe[2];
+static int child_pipe1[2];
+static int child_pipe2[2];
+static int child_pipe3[2];
+static int file_fd;
+static pid_t parent_pid, child_pid1, child_pid2, child_pid3;
+static int child_stat;
+static struct flock lock1 = { (short)F_WRLCK, (short)0, 2, 5, (short)0 };
+static struct flock lock2 = { (short)F_WRLCK, (short)0, 9, 5, (short)0 };
+static struct flock lock3 = { (short)F_WRLCK, (short)0, 17, 5, (short)0 };
+static struct flock lock4 = { (short)F_WRLCK, (short)0, 17, 5, (short)0 };
+static struct flock lock5 = { (short)F_WRLCK, (short)0, 2, 14, (short)0 };
+static struct flock unlock = { (short)F_UNLCK, (short)0, 0, 0, (short)0 };
 
 /* prototype declarations */
-int setup();
-void cleanup();
-int parent_wait();
-void parent_free();
-void child_wait();
-void child_free();
-void do_child1();
-void do_child2();
-void do_child3();
-int do_test(struct flock *, pid_t);
-void stop_children();
-void catch_child();
-void catch_alarm();
-char *str_type();
+static int setup();
+static void cleanup();
+static int parent_wait();
+static void parent_free();
+static void child_wait();
+static void child_free();
+static void do_child1();
+static void do_child2();
+static void do_child3();
+static int do_test(struct flock *, pid_t);
+static void stop_children();
+static void catch_child();
+static void catch_alarm();
+static char *str_type();
 
-int setup(void)
+static int setup(void)
 {
 	char *buf = STRING;
 	char template[PATH_MAX];
@@ -158,7 +158,7 @@ int setup(void)
 	return 0;
 }
 
-void cleanup(void)
+static void cleanup(void)
 {
 	if (child_pid1 > 0)
 		kill(child_pid1, 9);
@@ -174,7 +174,7 @@ void cleanup(void)
 
 }
 
-void do_child1(void)
+static void do_child1(void)
 {
 	int err;
 
@@ -206,7 +206,7 @@ void do_child1(void)
 	exit(1);
 }
 
-void do_child2(void)
+static void do_child2(void)
 {
 	int err;
 
@@ -244,7 +244,7 @@ void do_child2(void)
 	exit(1);
 }
 
-void do_child3(void)
+static void do_child3(void)
 {
 	int err;
 
@@ -282,7 +282,7 @@ void do_child3(void)
 	exit(1);
 }
 
-int do_test(struct flock *lock, pid_t pid)
+static int do_test(struct flock *lock, pid_t pid)
 {
 	struct flock fl;
 
@@ -330,7 +330,7 @@ int do_test(struct flock *lock, pid_t pid)
 	return 0;
 }
 
-char *str_type(int type)
+static char *str_type(int type)
 {
 	static char buf[20];
 
@@ -347,7 +347,7 @@ char *str_type(int type)
 	}
 }
 
-void parent_free(int arg)
+static void parent_free(int arg)
 {
 	if (write(parent_pipe[1], &arg, sizeof(arg)) != sizeof(arg)) {
 		tst_resm(TFAIL, "couldn't send message to parent");
@@ -355,7 +355,7 @@ void parent_free(int arg)
 	}
 }
 
-int parent_wait(void)
+static int parent_wait(void)
 {
 	int arg;
 
@@ -366,7 +366,7 @@ int parent_wait(void)
 	return (arg);
 }
 
-void child_free(int fd, int arg)
+static void child_free(int fd, int arg)
 {
 	if (write(fd, &arg, sizeof(arg)) != sizeof(arg)) {
 		tst_resm(TFAIL, "couldn't send message to child");
@@ -374,7 +374,7 @@ void child_free(int fd, int arg)
 	}
 }
 
-void child_wait(int fd)
+static void child_wait(int fd)
 {
 	int arg;
 
@@ -386,7 +386,7 @@ void child_wait(int fd)
 	}
 }
 
-void stop_children(void)
+static void stop_children(void)
 {
 	int arg;
 
@@ -403,13 +403,13 @@ void stop_children(void)
 	child_pid3 = 0;
 }
 
-void catch_child(void)
+static void catch_child(void)
 {
 	tst_resm(TFAIL, "Unexpected death of child process");
 	cleanup();
 }
 
-void catch_alarm(void)
+static void catch_alarm(void)
 {
 	sighold(SIGCHLD);
 	/*

--- a/testcases/kernel/syscalls/fcntl/fcntl18.c
+++ b/testcases/kernel/syscalls/fcntl/fcntl18.c
@@ -48,15 +48,15 @@
 #define INVAL_FLAG	-1
 #define INVAL_MIN	(-2147483647L-1L)
 
-int fd;
+static int fd;
 char string[40] = "";
 
-char *TCID = "fcntl18";
-int TST_TOTAL = 1;
+static char *TCID = "fcntl18";
+static int TST_TOTAL = 1;
 struct passwd *pass;
 
-void setup(void);
-void cleanup(void);
+static void setup(void);
+static void cleanup(void);
 int fail;
 
 int main(int ac, char **av)
@@ -166,7 +166,7 @@ int main(int ac, char **av)
  * setup()
  *	performs all ONE TIME setup for this test
  */
-void setup(void)
+static void setup(void)
 {
 
 	tst_sig(FORK, DEF_HANDLER, cleanup);
@@ -188,7 +188,7 @@ void setup(void)
  *	performs all the ONE TIME cleanup for this test at completion or
  *	or premature exit.
  */
-void cleanup(void)
+static void cleanup(void)
 {
 	/*
 	 * print timing status if that option was specified.

--- a/testcases/kernel/syscalls/fcntl/fcntl19.c
+++ b/testcases/kernel/syscalls/fcntl/fcntl19.c
@@ -55,32 +55,32 @@
 #define STRING		"abcdefghijklmnopqrstuvwxyz\n"
 #define STOP		0xFFF0
 
-int parent_pipe[2];
-int child_pipe[2];
-int fd;
-pid_t parent_pid, child_pid;
+static int parent_pipe[2];
+static int child_pipe[2];
+static int fd;
+static pid_t parent_pid, child_pid;
 
-void parent_put();
-void parent_get();
-void child_put();
-void child_get();
-void stop_child();
-void compare_lock(struct flock *, short, short, int, int, pid_t);
-void unlock_file();
-void do_test(struct flock *, short, short, int, int);
-void catch_child();
-char *str_type();
-int do_lock(int, short, short, int, int);
+static void parent_put();
+static void parent_get();
+static void child_put();
+static void child_get();
+static void stop_child();
+static void compare_lock(struct flock *, short, short, int, int, pid_t);
+static void unlock_file();
+static void do_test(struct flock *, short, short, int, int);
+static void catch_child();
+static char *str_type();
+static int do_lock(int, short, short, int, int);
 
-char *TCID = "fcntl19";
-int TST_TOTAL = 1;
+static char *TCID = "fcntl19";
+static int TST_TOTAL = 1;
 
-void setup(void);
-void cleanup(void);
+static void setup(void);
+static void cleanup(void);
 
-int fail = 0;
+static int fail = 0;
 
-void setup(void)
+static void setup(void)
 {
 	char *buf = STRING;
 	char template[PATH_MAX];
@@ -119,13 +119,13 @@ void setup(void)
 	}
 }
 
-void cleanup(void)
+static void cleanup(void)
 {
 	tst_rmdir();
 
 }
 
-void do_child(void)
+static void do_child(void)
 {
 	struct flock fl;
 
@@ -139,7 +139,7 @@ void do_child(void)
 	}
 }
 
-int do_lock(int cmd, short type, short whence, int start, int len)
+static int do_lock(int cmd, short type, short whence, int start, int len)
 {
 	struct flock fl;
 
@@ -150,7 +150,7 @@ int do_lock(int cmd, short type, short whence, int start, int len)
 	return (fcntl(fd, cmd, &fl));
 }
 
-void do_test(struct flock *fl, short type, short whence, int start, int len)
+static void do_test(struct flock *fl, short type, short whence, int start, int len)
 {
 	fl->l_type = type;
 	fl->l_whence = whence;
@@ -162,7 +162,7 @@ void do_test(struct flock *fl, short type, short whence, int start, int len)
 	parent_get(fl);
 }
 
-void
+static void
 compare_lock(struct flock *fl, short type, short whence, int start, int len,
 	     pid_t pid)
 {
@@ -198,7 +198,7 @@ compare_lock(struct flock *fl, short type, short whence, int start, int len,
 	}
 }
 
-void unlock_file(void)
+static void unlock_file(void)
 {
 	struct flock fl;
 
@@ -210,7 +210,7 @@ void unlock_file(void)
 	compare_lock(&fl, (short)F_UNLCK, (short)0, 0, 0, (pid_t) 0);
 }
 
-char *str_type(int type)
+static char *str_type(int type)
 {
 	static char buf[20];
 
@@ -227,7 +227,7 @@ char *str_type(int type)
 	}
 }
 
-void parent_put(struct flock *l)
+static void parent_put(struct flock *l)
 {
 	if (write(parent_pipe[1], l, sizeof(*l)) != sizeof(*l)) {
 		tst_resm(TFAIL, "couldn't send message to child");
@@ -235,7 +235,7 @@ void parent_put(struct flock *l)
 	}
 }
 
-void parent_get(struct flock *l)
+static void parent_get(struct flock *l)
 {
 	if (read(child_pipe[0], l, sizeof(*l)) != sizeof(*l)) {
 		tst_resm(TFAIL, "couldn't get message from child");
@@ -243,7 +243,7 @@ void parent_get(struct flock *l)
 	}
 }
 
-void child_put(struct flock *l)
+static void child_put(struct flock *l)
 {
 	if (write(child_pipe[1], l, sizeof(*l)) != sizeof(*l)) {
 		tst_resm(TFAIL, "couldn't send message to parent");
@@ -251,7 +251,7 @@ void child_put(struct flock *l)
 	}
 }
 
-void child_get(struct flock *l)
+static void child_get(struct flock *l)
 {
 	if (read(parent_pipe[0], l, sizeof(*l)) != sizeof(*l)) {
 		tst_resm(TFAIL, "couldn't get message from parent");
@@ -261,7 +261,7 @@ void child_get(struct flock *l)
 	}
 }
 
-void stop_child(void)
+static void stop_child(void)
 {
 	struct flock fl;
 
@@ -271,7 +271,7 @@ void stop_child(void)
 	wait(0);
 }
 
-void catch_child(void)
+static void catch_child(void)
 {
 	tst_resm(TFAIL, "Unexpected death of child process");
 	cleanup();

--- a/testcases/kernel/syscalls/fcntl/fcntl20.c
+++ b/testcases/kernel/syscalls/fcntl/fcntl20.c
@@ -51,36 +51,36 @@
 #define STRING		"abcdefghijklmnopqrstuvwxyz\n"
 #define STOP		0xFFF0
 
-int parent_pipe[2];
-int child_pipe[2];
-int fd;
-pid_t parent_pid, child_pid;
+static int parent_pipe[2];
+static int child_pipe[2];
+static int fd;
+static pid_t parent_pid, child_pid;
 
-void parent_put();
-void parent_get();
-void child_put();
-void child_get();
-void stop_child();
-void compare_lock(struct flock *, short, short, int, int, pid_t);
-void unlock_file();
-void do_test(struct flock *, short, short, int, int);
-void catch_child();
-char *str_type();
-int do_lock(int, short, short, int, int);
+static void parent_put();
+static void parent_get();
+static void child_put();
+static void child_get();
+static void stop_child();
+static void compare_lock(struct flock *, short, short, int, int, pid_t);
+static void unlock_file();
+static void do_test(struct flock *, short, short, int, int);
+static void catch_child();
+static char *str_type();
+static int do_lock(int, short, short, int, int);
 
-char *TCID = "fcntl20";
-int TST_TOTAL = 1;
+static char *TCID = "fcntl20";
+static int TST_TOTAL = 1;
 
-void setup(void);
-void cleanup(void);
+static void setup(void);
+static void cleanup(void);
 
-int fail = 0;
+static int fail = 0;
 
 /*
  * setup
  *	performs all ONE TIME setup for this test
  */
-void setup(void)
+static void setup(void)
 {
 	char *buf = STRING;
 	char template[PATH_MAX];
@@ -114,7 +114,7 @@ void setup(void)
 		tst_brkm(TFAIL | TERRNO, cleanup, "SIGCHLD signal setup failed");
 }
 
-void cleanup(void)
+static void cleanup(void)
 {
 	SAFE_CLOSE(NULL, fd);
 
@@ -122,7 +122,7 @@ void cleanup(void)
 
 }
 
-void do_child(void)
+static void do_child(void)
 {
 	struct flock fl;
 
@@ -138,7 +138,7 @@ void do_child(void)
 	}
 }
 
-int do_lock(int cmd, short type, short whence, int start, int len)
+static int do_lock(int cmd, short type, short whence, int start, int len)
 {
 	struct flock fl;
 
@@ -149,7 +149,7 @@ int do_lock(int cmd, short type, short whence, int start, int len)
 	return (fcntl(fd, cmd, &fl));
 }
 
-void do_test(struct flock *fl, short type, short whence, int start, int len)
+static void do_test(struct flock *fl, short type, short whence, int start, int len)
 {
 	fl->l_type = type;
 	fl->l_whence = whence;
@@ -161,7 +161,7 @@ void do_test(struct flock *fl, short type, short whence, int start, int len)
 	parent_get(fl);
 }
 
-void
+static void
 compare_lock(struct flock *fl, short type, short whence, int start, int len,
 	     pid_t pid)
 {
@@ -197,7 +197,7 @@ compare_lock(struct flock *fl, short type, short whence, int start, int len,
 	}
 }
 
-void unlock_file(void)
+static void unlock_file(void)
 {
 	struct flock fl;
 
@@ -209,7 +209,7 @@ void unlock_file(void)
 	compare_lock(&fl, (short)F_UNLCK, (short)0, 0, 0, (pid_t) 0);
 }
 
-char *str_type(int type)
+static char *str_type(int type)
 {
 	static char buf[20];
 
@@ -226,7 +226,7 @@ char *str_type(int type)
 	}
 }
 
-void parent_put(struct flock *l)
+static void parent_put(struct flock *l)
 {
 	if (write(parent_pipe[1], l, sizeof(*l)) != sizeof(*l)) {
 		tst_resm(TFAIL, "couldn't send message to child");
@@ -234,7 +234,7 @@ void parent_put(struct flock *l)
 	}
 }
 
-void parent_get(struct flock *l)
+static void parent_get(struct flock *l)
 {
 	if (read(child_pipe[0], l, sizeof(*l)) != sizeof(*l)) {
 		tst_resm(TFAIL, "couldn't get message from child");
@@ -242,7 +242,7 @@ void parent_get(struct flock *l)
 	}
 }
 
-void child_put(struct flock *l)
+static void child_put(struct flock *l)
 {
 	if (write(child_pipe[1], l, sizeof(*l)) != sizeof(*l)) {
 		tst_resm(TFAIL, "couldn't send message to parent");
@@ -250,7 +250,7 @@ void child_put(struct flock *l)
 	}
 }
 
-void child_get(struct flock *l)
+static void child_get(struct flock *l)
 {
 	if (read(parent_pipe[0], l, sizeof(*l)) != sizeof(*l)) {
 		tst_resm(TFAIL, "couldn't get message from parent");
@@ -260,7 +260,7 @@ void child_get(struct flock *l)
 	}
 }
 
-void stop_child(void)
+static void stop_child(void)
 {
 	struct flock fl;
 
@@ -270,7 +270,7 @@ void stop_child(void)
 	wait(0);
 }
 
-void catch_child(void)
+static void catch_child(void)
 {
 	tst_resm(TFAIL, "Unexpected death of child process");
 	cleanup();

--- a/testcases/kernel/syscalls/fcntl/fcntl21.c
+++ b/testcases/kernel/syscalls/fcntl/fcntl21.c
@@ -50,35 +50,35 @@
 #define STRING		"abcdefghijklmnopqrstuvwxyz\n"
 #define STOP		0xFFF0
 
-int parent_pipe[2];
-int child_pipe[2];
-int fd;
-pid_t parent_pid, child_pid;
+static int parent_pipe[2];
+static int child_pipe[2];
+static int fd;
+static pid_t parent_pid, child_pid;
 
-void parent_put();
-void parent_get();
-void child_put();
-void child_get();
-void stop_child();
-void compare_lock(struct flock *, short, short, int, int, pid_t);
-void unlock_file();
-void do_test(struct flock *, short, short, int, int);
-void catch_child();
-char *str_type();
-int do_lock(int, short, short, int, int);
+static void parent_put();
+static void parent_get();
+static void child_put();
+static void child_get();
+static void stop_child();
+static void compare_lock(struct flock *, short, short, int, int, pid_t);
+static void unlock_file();
+static void do_test(struct flock *, short, short, int, int);
+static void catch_child();
+static char *str_type();
+static int do_lock(int, short, short, int, int);
 
-char *TCID = "fcntl21";
-int TST_TOTAL = 1;
+static char *TCID = "fcntl21";
+static int TST_TOTAL = 1;
 
-void setup(void);
-void cleanup(void);
-int fail;
+static void setup(void);
+static void cleanup(void);
+static int fail;
 
 /*
  * setup
  *	performs all ONE TIME setup for this test
  */
-void setup(void)
+static void setup(void)
 {
 	char *buf = STRING;
 	char template[PATH_MAX];
@@ -122,14 +122,14 @@ void setup(void)
  *	performs all ONE TIME cleanup for this test at completion or
  *	premature exit
  */
-void cleanup(void)
+static void cleanup(void)
 {
 
 	tst_rmdir();
 
 }
 
-void do_child(void)
+static void do_child(void)
 {
 	struct flock fl;
 
@@ -146,7 +146,7 @@ void do_child(void)
 	}
 }
 
-int do_lock(int cmd, short type, short whence, int start, int len)
+static int do_lock(int cmd, short type, short whence, int start, int len)
 {
 	struct flock fl;
 
@@ -157,7 +157,7 @@ int do_lock(int cmd, short type, short whence, int start, int len)
 	return (fcntl(fd, cmd, &fl));
 }
 
-void do_test(struct flock *fl, short type, short whence, int start, int len)
+static void do_test(struct flock *fl, short type, short whence, int start, int len)
 {
 	fl->l_type = type;
 	fl->l_whence = whence;
@@ -169,7 +169,7 @@ void do_test(struct flock *fl, short type, short whence, int start, int len)
 	parent_get(fl);
 }
 
-void
+static void
 compare_lock(struct flock *fl, short type, short whence, int start, int len,
 	     pid_t pid)
 {
@@ -205,7 +205,7 @@ compare_lock(struct flock *fl, short type, short whence, int start, int len,
 	}
 }
 
-void unlock_file(void)
+static void unlock_file(void)
 {
 	struct flock fl;
 
@@ -217,7 +217,7 @@ void unlock_file(void)
 	compare_lock(&fl, (short)F_UNLCK, (short)0, 0, 0, (pid_t) 0);
 }
 
-char *str_type(int type)
+static char *str_type(int type)
 {
 	static char buf[20];
 
@@ -234,7 +234,7 @@ char *str_type(int type)
 	}
 }
 
-void parent_put(struct flock *l)
+static void parent_put(struct flock *l)
 {
 	if (write(parent_pipe[1], l, sizeof(*l)) != sizeof(*l)) {
 		tst_resm(TFAIL, "couldn't send message to child");
@@ -242,7 +242,7 @@ void parent_put(struct flock *l)
 	}
 }
 
-void parent_get(struct flock *l)
+static void parent_get(struct flock *l)
 {
 	if (read(child_pipe[0], l, sizeof(*l)) != sizeof(*l)) {
 		tst_resm(TFAIL, "couldn't get message from child");
@@ -250,7 +250,7 @@ void parent_get(struct flock *l)
 	}
 }
 
-void child_put(struct flock *l)
+static void child_put(struct flock *l)
 {
 	if (write(child_pipe[1], l, sizeof(*l)) != sizeof(*l)) {
 		tst_resm(TFAIL, "couldn't send message to parent");
@@ -258,7 +258,7 @@ void child_put(struct flock *l)
 	}
 }
 
-void child_get(struct flock *l)
+static void child_get(struct flock *l)
 {
 	if (read(parent_pipe[0], l, sizeof(*l)) != sizeof(*l)) {
 		tst_resm(TFAIL, "couldn't get message from parent");
@@ -268,7 +268,7 @@ void child_get(struct flock *l)
 	}
 }
 
-void stop_child(void)
+static void stop_child(void)
 {
 	struct flock fl;
 
@@ -278,7 +278,7 @@ void stop_child(void)
 	wait(0);
 }
 
-void catch_child(void)
+static void catch_child(void)
 {
 	tst_resm(TFAIL, "Unexpected death of child process");
 	cleanup();

--- a/testcases/kernel/syscalls/fcntl/fcntl22.c
+++ b/testcases/kernel/syscalls/fcntl/fcntl22.c
@@ -39,15 +39,15 @@
 #include <sys/wait.h>
 #include "test.h"
 
-int child_pid;
-int file;
-struct flock fl;
+static int child_pid;
+static int file;
+static struct flock fl;
 
-char *TCID = "fcntl22";
-int TST_TOTAL = 1;
+static char *TCID = "fcntl22";
+static int TST_TOTAL = 1;
 
-void setup(void);
-void cleanup(void);
+static void setup(void);
+static void cleanup(void);
 
 int main(int ac, char **av)
 {
@@ -96,7 +96,7 @@ int main(int ac, char **av)
 	tst_exit();
 }
 
-void setup(void)
+static void setup(void)
 {
 	tst_sig(FORK, DEF_HANDLER, cleanup);
 
@@ -119,7 +119,7 @@ void setup(void)
 		tst_brkm(TBROK | TERRNO, cleanup, "fcntl() failed");
 }
 
-void cleanup(void)
+static void cleanup(void)
 {
 	close(file);
 

--- a/testcases/kernel/syscalls/fcntl/fcntl23.c
+++ b/testcases/kernel/syscalls/fcntl/fcntl23.c
@@ -94,14 +94,14 @@
 #include <signal.h>
 #include "test.h"
 
-void setup();
-void cleanup();
+static void setup();
+static void cleanup();
 
-char *TCID = "fcntl23";
-int TST_TOTAL = 1;
+static char *TCID = "fcntl23";
+static int TST_TOTAL = 1;
 
-char fname[255];
-int fd;
+static char fname[255];
+static int fd;
 
 int main(int ac, char **av)
 {
@@ -177,7 +177,7 @@ int main(int ac, char **av)
 /***************************************************************
  * setup() - performs all ONE TIME setup for this test.
  ***************************************************************/
-void setup(void)
+static void setup(void)
 {
 
 	tst_sig(NOFORK, DEF_HANDLER, cleanup);
@@ -198,7 +198,7 @@ void setup(void)
  * cleanup() - performs all ONE TIME cleanup for this test at
  *		completion or premature exit.
  ***************************************************************/
-void cleanup(void)
+static void cleanup(void)
 {
 
 	/* close the file we've had open */

--- a/testcases/kernel/syscalls/fcntl/fcntl24.c
+++ b/testcases/kernel/syscalls/fcntl/fcntl24.c
@@ -94,14 +94,14 @@
 #include <signal.h>
 #include "test.h"
 
-void setup();
-void cleanup();
+static void setup();
+static void cleanup();
 
-char *TCID = "fcntl24";
-int TST_TOTAL = 1;
+static char *TCID = "fcntl24";
+static int TST_TOTAL = 1;
 
-char fname[255];
-int fd;
+static char fname[255];
+static int fd;
 
 int main(int ac, char **av)
 {
@@ -181,7 +181,7 @@ int main(int ac, char **av)
 /***************************************************************
  * setup() - performs all ONE TIME setup for this test.
  ***************************************************************/
-void setup(void)
+static void setup(void)
 {
 
 	tst_sig(NOFORK, DEF_HANDLER, cleanup);
@@ -202,7 +202,7 @@ void setup(void)
  * cleanup() - performs all ONE TIME cleanup for this test at
  *		completion or premature exit.
  ***************************************************************/
-void cleanup(void)
+static void cleanup(void)
 {
 
 	/* close the file we've had open */

--- a/testcases/kernel/syscalls/fcntl/fcntl25.c
+++ b/testcases/kernel/syscalls/fcntl/fcntl25.c
@@ -95,14 +95,14 @@
 #include <signal.h>
 #include "test.h"
 
-void setup();
-void cleanup();
+static void setup();
+static void cleanup();
 
-char *TCID = "fcntl25";
-int TST_TOTAL = 1;
+static char *TCID = "fcntl25";
+static int TST_TOTAL = 1;
 
-char fname[255];
-int fd;
+static char fname[255];
+static int fd;
 
 int main(int ac, char **av)
 {
@@ -182,7 +182,7 @@ int main(int ac, char **av)
 /***************************************************************
  * setup() - performs all ONE TIME setup for this test.
  ***************************************************************/
-void setup(void)
+static void setup(void)
 {
 
 	tst_sig(NOFORK, DEF_HANDLER, cleanup);
@@ -203,7 +203,7 @@ void setup(void)
  * cleanup() - performs all ONE TIME cleanup for this test at
  *				 completion or premature exit.
  ***************************************************************/
-void cleanup(void)
+static void cleanup(void)
 {
 
 	/* close the file we've had open */

--- a/testcases/kernel/syscalls/fcntl/fcntl26.c
+++ b/testcases/kernel/syscalls/fcntl/fcntl26.c
@@ -95,14 +95,14 @@
 #include <signal.h>
 #include "test.h"
 
-void setup();
-void cleanup();
+static void setup();
+static void cleanup();
 
-char *TCID = "fcntl26";
-int TST_TOTAL = 1;
+static char *TCID = "fcntl26";
+static int TST_TOTAL = 1;
 
-char fname[255];
-int fd;
+static char fname[255];
+static int fd;
 
 int main(int ac, char **av)
 {
@@ -182,7 +182,7 @@ int main(int ac, char **av)
 /***************************************************************
  * setup() - performs all ONE TIME setup for this test.
  ***************************************************************/
-void setup(void)
+static void setup(void)
 {
 
 	tst_sig(NOFORK, DEF_HANDLER, cleanup);
@@ -203,7 +203,7 @@ void setup(void)
  * cleanup() - performs all ONE TIME cleanup for this test at
  *				 completion or premature exit.
  ***************************************************************/
-void cleanup(void)
+static void cleanup(void)
 {
 
 	/* close the file we've had open */

--- a/testcases/kernel/syscalls/fcntl/fcntl27.c
+++ b/testcases/kernel/syscalls/fcntl/fcntl27.c
@@ -95,14 +95,14 @@
 #include <signal.h>
 #include "test.h"
 
-void setup();
-void cleanup();
+static void setup();
+static void cleanup();
 
-char *TCID = "fcntl27";
-int TST_TOTAL = 1;
+static char *TCID = "fcntl27";
+static int TST_TOTAL = 1;
 
-char fname[255];
-int fd;
+static char fname[255];
+static int fd;
 
 int main(int ac, char **av)
 {
@@ -157,7 +157,7 @@ int main(int ac, char **av)
 /***************************************************************
  * setup() - performs all ONE TIME setup for this test.
  ***************************************************************/
-void setup(void)
+static void setup(void)
 {
 
 	tst_sig(NOFORK, DEF_HANDLER, cleanup);
@@ -178,7 +178,7 @@ void setup(void)
  * cleanup() - performs all ONE TIME cleanup for this test at
  *				 completion or premature exit.
  ***************************************************************/
-void cleanup(void)
+static void cleanup(void)
 {
 
 	/* close the file we've had open */

--- a/testcases/kernel/syscalls/fcntl/fcntl28.c
+++ b/testcases/kernel/syscalls/fcntl/fcntl28.c
@@ -92,14 +92,14 @@
 #include <signal.h>
 #include "test.h"
 
-void setup();
-void cleanup();
+static void setup();
+static void cleanup();
 
-char *TCID = "fcntl28";
-int TST_TOTAL = 1;
+static char *TCID = "fcntl28";
+static int TST_TOTAL = 1;
 
-char fname[255];
-int fd;
+static char fname[255];
+static int fd;
 
 int main(int ac, char **av)
 {
@@ -155,7 +155,7 @@ int main(int ac, char **av)
 /***************************************************************
  * setup() - performs all ONE TIME setup for this test.
  ***************************************************************/
-void setup(void)
+static void setup(void)
 {
 
 	tst_sig(NOFORK, DEF_HANDLER, cleanup);
@@ -176,7 +176,7 @@ void setup(void)
  * cleanup() - performs all ONE TIME cleanup for this test at
  *				 completion or premature exit.
  ***************************************************************/
-void cleanup(void)
+static void cleanup(void)
 {
 
 	/* close the file we've had open */

--- a/testcases/kernel/syscalls/fcntl/fcntl29.c
+++ b/testcases/kernel/syscalls/fcntl/fcntl29.c
@@ -35,8 +35,8 @@
 #include "safe_macros.h"
 #include "lapi/fcntl.h"
 
-char *TCID = "fcntl29";
-int TST_TOTAL = 1;
+static char *TCID = "fcntl29";
+static int TST_TOTAL = 1;
 
 static void setup(void);
 static void cleanup(void);

--- a/testcases/kernel/syscalls/fcntl/fcntl30.c
+++ b/testcases/kernel/syscalls/fcntl/fcntl30.c
@@ -35,8 +35,8 @@
 #include "safe_macros.h"
 #include "lapi/fcntl.h"
 
-char *TCID = "fcntl30";
-int TST_TOTAL = 1;
+static char *TCID = "fcntl30";
+static int TST_TOTAL = 1;
 
 static void setup(void);
 static void cleanup(void);

--- a/testcases/kernel/syscalls/fcntl/fcntl32.c
+++ b/testcases/kernel/syscalls/fcntl/fcntl32.c
@@ -51,8 +51,8 @@ static struct test_case_t {
 	{O_RDWR, O_RDWR},
 };
 
-char *TCID = "fcntl32";
-int TST_TOTAL = ARRAY_SIZE(test_cases);
+static char *TCID = "fcntl32";
+static int TST_TOTAL = ARRAY_SIZE(test_cases);
 
 int main(int ac, char **av)
 {

--- a/testcases/kernel/syscalls/fork/fork01.c
+++ b/testcases/kernel/syscalls/fork/fork01.c
@@ -102,8 +102,8 @@ static void cleanup();
 #define LINE_SZ	20
 #define FILENAME "childpid"
 
-char *TCID = "fork01";
-int TST_TOTAL = 2;
+static char *TCID = "fork01";
+static int TST_TOTAL = 2;
 
 /*
  * child_pid - the child side of the test

--- a/testcases/kernel/syscalls/fork/fork02.c
+++ b/testcases/kernel/syscalls/fork/fork02.c
@@ -49,8 +49,8 @@
 static void setup(void);
 static void cleanup(void);
 
-char *TCID = "fork02";
-int TST_TOTAL = 1;
+static char *TCID = "fork02";
+static int TST_TOTAL = 1;
 
 int main(int ac, char **av)
 {

--- a/testcases/kernel/syscalls/fork/fork03.c
+++ b/testcases/kernel/syscalls/fork/fork03.c
@@ -44,8 +44,8 @@
 #include <stdio.h>
 #include "test.h"
 
-char *TCID = "fork03";
-int TST_TOTAL = 1;
+static char *TCID = "fork03";
+static int TST_TOTAL = 1;
 
 static void setup(void);
 static void cleanup(void);

--- a/testcases/kernel/syscalls/fork/fork04.c
+++ b/testcases/kernel/syscalls/fork/fork04.c
@@ -105,7 +105,7 @@
 #include "test.h"
 #include "safe_macros.h"
 
-char *TCID = "fork04";
+static char *TCID = "fork04";
 
 #define	KIDEXIT	42
 #define MAX_LINE_LENGTH 256
@@ -113,10 +113,10 @@ char *TCID = "fork04";
 #define ENV_NOT_SET  "getenv() does not find variable set"
 
 /* list of environment variables to test */
-char *environ_list[] = { "TERM", "NoTSetzWq", "TESTPROG" };
+static char *environ_list[] = { "TERM", "NoTSetzWq", "TESTPROG" };
 
 #define NUMBER_OF_ENVIRON (sizeof(environ_list)/sizeof(char *))
-int TST_TOTAL = NUMBER_OF_ENVIRON;
+static int TST_TOTAL = NUMBER_OF_ENVIRON;
 
 static void cleanup(void)
 {

--- a/testcases/kernel/syscalls/fork/fork06.c
+++ b/testcases/kernel/syscalls/fork/fork06.c
@@ -42,8 +42,8 @@
 #include <stdio.h>
 #include "test.h"
 
-char *TCID = "fork06";
-int TST_TOTAL = 1;
+static char *TCID = "fork06";
+static int TST_TOTAL = 1;
 
 static void setup(void);
 static void cleanup(void);

--- a/testcases/kernel/syscalls/fork/fork07.c
+++ b/testcases/kernel/syscalls/fork/fork07.c
@@ -47,8 +47,8 @@
 #include <sys/stat.h>
 #include "test.h"
 
-char *TCID = "fork07";
-int TST_TOTAL = 1;
+static char *TCID = "fork07";
+static int TST_TOTAL = 1;
 
 static void help(void);
 static void setup(void);

--- a/testcases/kernel/syscalls/fork/fork08.c
+++ b/testcases/kernel/syscalls/fork/fork08.c
@@ -44,8 +44,8 @@
 #include <stdio.h>
 #include "test.h"
 
-char *TCID = "fork08";
-int TST_TOTAL = 1;
+static char *TCID = "fork08";
+static int TST_TOTAL = 1;
 
 static void setup(void);
 static void cleanup(void);

--- a/testcases/kernel/syscalls/fork/fork09.c
+++ b/testcases/kernel/syscalls/fork/fork09.c
@@ -49,8 +49,8 @@
 #include "test.h"
 #include "safe_macros.h"
 
-char *TCID = "fork09";
-int TST_TOTAL = 1;
+static char *TCID = "fork09";
+static int TST_TOTAL = 1;
 
 static void setup(void);
 static void cleanup(void);

--- a/testcases/kernel/syscalls/fork/fork10.c
+++ b/testcases/kernel/syscalls/fork/fork10.c
@@ -47,8 +47,8 @@
 #include "test.h"
 #include "safe_macros.h"
 
-char *TCID = "fork10";
-int TST_TOTAL = 1;
+static char *TCID = "fork10";
+static int TST_TOTAL = 1;
 
 static void setup(void);
 static void cleanup(void);

--- a/testcases/kernel/syscalls/fork/fork11.c
+++ b/testcases/kernel/syscalls/fork/fork11.c
@@ -41,8 +41,8 @@
 #include <errno.h>
 #include "test.h"
 
-char *TCID = "fork11";
-int TST_TOTAL = 1;
+static char *TCID = "fork11";
+static int TST_TOTAL = 1;
 
 static void setup(void);
 static void cleanup(void);

--- a/testcases/kernel/syscalls/fork/fork12.c
+++ b/testcases/kernel/syscalls/fork/fork12.c
@@ -46,8 +46,8 @@
 #include "test.h"
 #include "safe_macros.h"
 
-char *TCID = "fork12";
-int TST_TOTAL = 1;
+static char *TCID = "fork12";
+static int TST_TOTAL = 1;
 
 static void setup(void);
 static void cleanup(void);

--- a/testcases/kernel/syscalls/fork/fork13.c
+++ b/testcases/kernel/syscalls/fork/fork13.c
@@ -56,8 +56,8 @@
 #include <stdlib.h>
 #include "test.h"
 
-char *TCID = "fork13";
-int TST_TOTAL = 1;
+static char *TCID = "fork13";
+static int TST_TOTAL = 1;
 
 static unsigned long pid_max;
 

--- a/testcases/kernel/syscalls/fork/fork14.c
+++ b/testcases/kernel/syscalls/fork/fork14.c
@@ -37,8 +37,8 @@
 #include "safe_macros.h"
 #include "lapi/abisize.h"
 
-char *TCID = "fork14";
-int TST_TOTAL = 1;
+static char *TCID = "fork14";
+static int TST_TOTAL = 1;
 
 #define GB		(1024 * 1024 * 1024L)
 

--- a/testcases/kernel/syscalls/fpathconf/fpathconf01.c
+++ b/testcases/kernel/syscalls/fpathconf/fpathconf01.c
@@ -63,8 +63,8 @@ static struct pathconf_args {
 	{"_PC_NO_TRUNC", _PC_NO_TRUNC},
 };
 
-char *TCID = "fpathconf01";
-int TST_TOTAL = ARRAY_SIZE(test_cases);
+static char *TCID = "fpathconf01";
+static int TST_TOTAL = ARRAY_SIZE(test_cases);
 
 static int fd;
 

--- a/testcases/kernel/syscalls/fsmount/fsmount02.c
+++ b/testcases/kernel/syscalls/fsmount/fsmount02.c
@@ -7,7 +7,7 @@
 #include "tst_test.h"
 #include "lapi/fsmount.h"
 
-int fd = -1, invalid_fd = -1;
+static int fd = -1, invalid_fd = -1;
 
 #define MNTPOINT	"mntpoint"
 

--- a/testcases/kernel/syscalls/fstatat/fstatat01.c
+++ b/testcases/kernel/syscalls/fstatat/fstatat01.c
@@ -42,11 +42,11 @@
 #define AT_FDCWD -100
 #endif
 
-void setup();
-void cleanup();
+static void setup();
+static void cleanup();
 
-char *TCID = "fstatat01";
-int TST_TOTAL = TEST_CASES;
+static char *TCID = "fstatat01";
+static int TST_TOTAL = TEST_CASES;
 
 static const char pathname[] = "fstatattestdir",
 		  testfile[] = "fstatattestfile.txt",
@@ -112,7 +112,7 @@ int main(int ac, char **av)
 	tst_exit();
 }
 
-void setup(void)
+static void setup(void)
 {
 	tst_sig(NOFORK, DEF_HANDLER, cleanup);
 
@@ -143,7 +143,7 @@ void setup(void)
 	TEST_PAUSE;
 }
 
-void cleanup(void)
+static void cleanup(void)
 {
 	if (fds[0] > 0)
 		close(fds[0]);

--- a/testcases/kernel/syscalls/fstatfs/fstatfs01.c
+++ b/testcases/kernel/syscalls/fstatfs/fstatfs01.c
@@ -51,7 +51,7 @@
 static void setup(void);
 static void cleanup(void);
 
-char *TCID = "fstatfs01";
+static char *TCID = "fstatfs01";
 
 static int file_fd;
 static int pipe_fd;
@@ -64,7 +64,7 @@ static struct tcase {
 	{&pipe_fd, "fstatfs() on a pipe"},
 };
 
-int TST_TOTAL = ARRAY_SIZE(tcases);
+static int TST_TOTAL = ARRAY_SIZE(tcases);
 
 int main(int ac, char **av)
 {

--- a/testcases/kernel/syscalls/fstatfs/fstatfs02.c
+++ b/testcases/kernel/syscalls/fstatfs/fstatfs02.c
@@ -31,7 +31,7 @@
 static void setup(void);
 static void cleanup(void);
 
-char *TCID = "fstatfs02";
+static char *TCID = "fstatfs02";
 
 static struct statfs buf;
 
@@ -51,7 +51,7 @@ static struct test_case_t {
 #endif
 };
 
-int TST_TOTAL = ARRAY_SIZE(TC);
+static int TST_TOTAL = ARRAY_SIZE(TC);
 
 int main(int ac, char **av)
 {

--- a/testcases/kernel/syscalls/fsync/fsync02.c
+++ b/testcases/kernel/syscalls/fsync/fsync02.c
@@ -24,10 +24,10 @@
 #define TIME_LIMIT 120
 #define BUF_SIZE 2048
 
-char tempfile[40] = "";
-char pbuf[BUF_SIZE];
-int fd;
-off_t max_blks = MAXBLKS;
+static char tempfile[40] = "";
+static char pbuf[BUF_SIZE];
+static int fd;
+static off_t max_blks = MAXBLKS;
 
 struct statvfs stat_buf;
 

--- a/testcases/kernel/syscalls/ftruncate/ftruncate04.c
+++ b/testcases/kernel/syscalls/ftruncate/ftruncate04.c
@@ -106,7 +106,7 @@ static void doparent(void)
 	SAFE_CLOSE(fd);
 }
 
-void dochild(void)
+static void dochild(void)
 {
 	int fd;
 	struct flock flocks;

--- a/testcases/kernel/syscalls/futimesat/futimesat01.c
+++ b/testcases/kernel/syscalls/futimesat/futimesat01.c
@@ -41,11 +41,11 @@
 #define AT_FDCWD -100
 #endif
 
-void setup();
-void cleanup();
+static void setup();
+static void cleanup();
 
-char *TCID = "futimesat01";
-int TST_TOTAL = TEST_CASES;
+static char *TCID = "futimesat01";
+static int TST_TOTAL = TEST_CASES;
 
 static const char pathname[] = "futimesattestdir",
 		  testfile[] = "futimesattestfile.txt",
@@ -56,7 +56,7 @@ static int fds[TEST_CASES];
 static const char *filenames[TEST_CASES];
 static const int expected_errno[] = { 0, 0, ENOTDIR, EBADF, 0 };
 
-int myfutimesat(int dirfd, const char *filename, struct timeval *times)
+static int myfutimesat(int dirfd, const char *filename, struct timeval *times)
 {
 	return ltp_syscall(__NR_futimesat, dirfd, filename, times);
 }
@@ -95,7 +95,7 @@ int main(int ac, char **av)
 	tst_exit();
 }
 
-void setup(void)
+static void setup(void)
 {
 	tst_sig(NOFORK, DEF_HANDLER, cleanup);
 
@@ -125,7 +125,7 @@ void setup(void)
 	TEST_PAUSE;
 }
 
-void cleanup(void)
+static void cleanup(void)
 {
 	if (fds[0] > 0)
 		close(fds[0]);

--- a/testcases/kernel/syscalls/getdtablesize/getdtablesize01.c
+++ b/testcases/kernel/syscalls/getdtablesize/getdtablesize01.c
@@ -46,11 +46,11 @@
 #include <unistd.h>
 #include "test.h"
 
-void setup();
-void cleanup();
+static void setup();
+static void cleanup();
 
-char *TCID = "getdtablesize01";
-int TST_TOTAL = 1;
+static char *TCID = "getdtablesize01";
+static int TST_TOTAL = 1;
 
 int main(void)
 {
@@ -107,13 +107,13 @@ int main(void)
 	tst_exit();
 }
 
-void setup(void)
+static void setup(void)
 {
 	tst_sig(NOFORK, DEF_HANDLER, cleanup);
 
 	TEST_PAUSE;
 }
 
-void cleanup(void)
+static void cleanup(void)
 {
 }

--- a/testcases/kernel/syscalls/getegid/getegid01.c
+++ b/testcases/kernel/syscalls/getegid/getegid01.c
@@ -48,7 +48,7 @@ static void setup();
 static void cleanup();
 
 TCID_DEFINE(getegid01);
-int TST_TOTAL = 1;
+static int TST_TOTAL = 1;
 
 int main(int ac, char **av)
 {

--- a/testcases/kernel/syscalls/getegid/getegid02.c
+++ b/testcases/kernel/syscalls/getegid/getegid02.c
@@ -34,7 +34,7 @@ static void cleanup(void);
 static void setup(void);
 
 TCID_DEFINE(getegid02);
-int TST_TOTAL = 1;
+static int TST_TOTAL = 1;
 
 int main(int ac, char **av)
 {

--- a/testcases/kernel/syscalls/geteuid/geteuid01.c
+++ b/testcases/kernel/syscalls/geteuid/geteuid01.c
@@ -48,7 +48,7 @@ static void setup(void);
 static void cleanup(void);
 
 TCID_DEFINE(geteuid01);
-int TST_TOTAL = 1;
+static int TST_TOTAL = 1;
 
 int main(int ac, char **av)
 {

--- a/testcases/kernel/syscalls/geteuid/geteuid02.c
+++ b/testcases/kernel/syscalls/geteuid/geteuid02.c
@@ -24,7 +24,7 @@
 #include "compat_16.h"
 
 TCID_DEFINE(geteuid02);
-int TST_TOTAL = 1;
+static int TST_TOTAL = 1;
 
 static void setup(void);
 static void cleanup(void);

--- a/testcases/kernel/syscalls/getgid/getgid01.c
+++ b/testcases/kernel/syscalls/getgid/getgid01.c
@@ -47,7 +47,7 @@ static void setup(void);
 static void cleanup(void);
 
 TCID_DEFINE(getgid01);
-int TST_TOTAL = 1;
+static int TST_TOTAL = 1;
 
 int main(int ac, char **av)
 {

--- a/testcases/kernel/syscalls/getgid/getgid03.c
+++ b/testcases/kernel/syscalls/getgid/getgid03.c
@@ -34,7 +34,7 @@ static void cleanup(void);
 static void setup(void);
 
 TCID_DEFINE(getgid03);
-int TST_TOTAL = 1;
+static int TST_TOTAL = 1;
 
 int main(int ac, char **av)
 {

--- a/testcases/kernel/syscalls/gethostbyname_r/gethostbyname_r01.c
+++ b/testcases/kernel/syscalls/gethostbyname_r/gethostbyname_r01.c
@@ -38,8 +38,8 @@ static struct {
 	CANARY,
 };
 
-char *TCID = "gethostbyname_r01";
-int TST_TOTAL = 1;
+static char *TCID = "gethostbyname_r01";
+static int TST_TOTAL = 1;
 
 int main(int ac, char **av)
 {

--- a/testcases/kernel/syscalls/gethostid/gethostid01.c
+++ b/testcases/kernel/syscalls/gethostid/gethostid01.c
@@ -130,11 +130,11 @@
 #define FIRST_64_CHKBIT  0x01
 #define SECOND_64_CHKBIT 0x02
 
-void setup();
-void cleanup();
+static void setup();
+static void cleanup();
 
-char *TCID = "gethostid01";
-int TST_TOTAL = 1;
+static char *TCID = "gethostid01";
+static int TST_TOTAL = 1;
 
 int main(int ac, char **av)
 {
@@ -237,7 +237,7 @@ int main(int ac, char **av)
 	tst_exit();
 }
 
-void setup(void)
+static void setup(void)
 {
 	char path[2048];
 
@@ -251,7 +251,7 @@ void setup(void)
 	tst_tmpdir();
 }
 
-void cleanup(void)
+static void cleanup(void)
 {
 	tst_rmdir();
 

--- a/testcases/kernel/syscalls/gethostname/gethostname01.c
+++ b/testcases/kernel/syscalls/gethostname/gethostname01.c
@@ -113,11 +113,11 @@
 
 #include "test.h"
 
-void setup();
-void cleanup();
+static void setup();
+static void cleanup();
 
-char *TCID = "gethostname01";
-int TST_TOTAL = 1;
+static char *TCID = "gethostname01";
+static int TST_TOTAL = 1;
 
 int main(int ac, char **av)
 {
@@ -148,7 +148,7 @@ int main(int ac, char **av)
 	tst_exit();
 }
 
-void setup(void)
+static void setup(void)
 {
 
 	tst_sig(NOFORK, DEF_HANDLER, cleanup);
@@ -156,6 +156,6 @@ void setup(void)
 	TEST_PAUSE;
 }
 
-void cleanup(void)
+static void cleanup(void)
 {
 }

--- a/testcases/kernel/syscalls/getitimer/getitimer01.c
+++ b/testcases/kernel/syscalls/getitimer/getitimer01.c
@@ -32,8 +32,8 @@
 static void cleanup(void);
 static void setup(void);
 
-char *TCID = "getitimer01";
-int TST_TOTAL = 3;
+static char *TCID = "getitimer01";
+static int TST_TOTAL = 3;
 
 static int itimer_name[] = {
 	ITIMER_REAL,

--- a/testcases/kernel/syscalls/getitimer/getitimer02.c
+++ b/testcases/kernel/syscalls/getitimer/getitimer02.c
@@ -31,8 +31,8 @@
 #include <errno.h>
 #include <sys/time.h>
 
-char *TCID = "getitimer02";
-int TST_TOTAL = 1;
+static char *TCID = "getitimer02";
+static int TST_TOTAL = 1;
 
 #if !defined(UCLINUX)
 

--- a/testcases/kernel/syscalls/getpagesize/getpagesize01.c
+++ b/testcases/kernel/syscalls/getpagesize/getpagesize01.c
@@ -42,11 +42,11 @@
 
 #include "test.h"
 
-void setup();
-void cleanup();
+static void setup();
+static void cleanup();
 
-char *TCID = "getpagesize01";
-int TST_TOTAL = 1;
+static char *TCID = "getpagesize01";
+static int TST_TOTAL = 1;
 
 int main(int ac, char **av)
 {
@@ -92,7 +92,7 @@ int main(int ac, char **av)
 	tst_exit();
 }
 
-void setup(void)
+static void setup(void)
 {
 
 	tst_sig(NOFORK, DEF_HANDLER, cleanup);
@@ -100,6 +100,6 @@ void setup(void)
 	TEST_PAUSE;
 }
 
-void cleanup(void)
+static void cleanup(void)
 {
 }

--- a/testcases/kernel/syscalls/getpgid/getpgid01.c
+++ b/testcases/kernel/syscalls/getpgid/getpgid01.c
@@ -50,11 +50,11 @@
 #include <sys/types.h>
 #include "test.h"
 
-void setup(void);
-void cleanup(void);
+static void setup(void);
+static void cleanup(void);
 
-char *TCID = "getpgid01";
-int TST_TOTAL = 1;
+static char *TCID = "getpgid01";
+static int TST_TOTAL = 1;
 
 int main(int ac, char **av)
 {
@@ -180,7 +180,7 @@ int main(int ac, char **av)
 
 }
 
-void setup(void)
+static void setup(void)
 {
 
 	tst_sig(FORK, DEF_HANDLER, cleanup);
@@ -188,6 +188,6 @@ void setup(void)
 	TEST_PAUSE;
 }
 
-void cleanup(void)
+static void cleanup(void)
 {
 }

--- a/testcases/kernel/syscalls/getpgrp/getpgrp01.c
+++ b/testcases/kernel/syscalls/getpgrp/getpgrp01.c
@@ -116,11 +116,11 @@
 #include <string.h>
 #include "test.h"
 
-void setup();
-void cleanup();
+static void setup();
+static void cleanup();
 
-char *TCID = "getpgrp01";
-int TST_TOTAL = 1;
+static char *TCID = "getpgrp01";
+static int TST_TOTAL = 1;
 
 int main(int ac, char **av)
 {
@@ -147,7 +147,7 @@ int main(int ac, char **av)
 	tst_exit();
 }
 
-void setup(void)
+static void setup(void)
 {
 
 	tst_sig(NOFORK, DEF_HANDLER, cleanup);
@@ -155,6 +155,6 @@ void setup(void)
 	TEST_PAUSE;
 }
 
-void cleanup(void)
+static void cleanup(void)
 {
 }

--- a/testcases/kernel/syscalls/getpid/getpid01.c
+++ b/testcases/kernel/syscalls/getpid/getpid01.c
@@ -114,11 +114,11 @@
 #include <string.h>
 #include "test.h"
 
-void setup();
-void cleanup();
+static void setup();
+static void cleanup();
 
-char *TCID = "getpid01";
-int TST_TOTAL = 1;
+static char *TCID = "getpid01";
+static int TST_TOTAL = 1;
 
 int main(int ac, char **av)
 {
@@ -145,7 +145,7 @@ int main(int ac, char **av)
 	tst_exit();
 }
 
-void setup(void)
+static void setup(void)
 {
 
 	tst_sig(NOFORK, DEF_HANDLER, cleanup);
@@ -153,6 +153,6 @@ void setup(void)
 	TEST_PAUSE;
 }
 
-void cleanup(void)
+static void cleanup(void)
 {
 }

--- a/testcases/kernel/syscalls/getpid/getpid02.c
+++ b/testcases/kernel/syscalls/getpid/getpid02.c
@@ -73,11 +73,11 @@
 #include "test.h"
 #include "safe_macros.h"
 
-void setup();			/* Main setup function of test */
-void cleanup();			/* cleanup function for the test */
+static void setup();			/* Main setup function of test */
+static void cleanup();			/* cleanup function for the test */
 
-char *TCID = "getpid02";
-int TST_TOTAL = 1;
+static char *TCID = "getpid02";
+static int TST_TOTAL = 1;
 
 int main(int ac, char **av)
 {
@@ -123,7 +123,7 @@ int main(int ac, char **av)
 	tst_exit();
 }
 
-void setup(void)
+static void setup(void)
 {
 
 	tst_sig(FORK, DEF_HANDLER, cleanup);
@@ -131,6 +131,6 @@ void setup(void)
 	TEST_PAUSE;
 }
 
-void cleanup(void)
+static void cleanup(void)
 {
 }

--- a/testcases/kernel/syscalls/getppid/getppid01.c
+++ b/testcases/kernel/syscalls/getppid/getppid01.c
@@ -116,11 +116,11 @@
 #include <signal.h>
 #include "test.h"
 
-void setup();
-void cleanup();
+static void setup();
+static void cleanup();
 
-char *TCID = "getppid01";
-int TST_TOTAL = 1;
+static char *TCID = "getppid01";
+static int TST_TOTAL = 1;
 
 int main(int ac, char **av)
 {
@@ -147,7 +147,7 @@ int main(int ac, char **av)
 	tst_exit();
 }
 
-void setup(void)
+static void setup(void)
 {
 
 	tst_sig(NOFORK, DEF_HANDLER, cleanup);
@@ -155,6 +155,6 @@ void setup(void)
 	TEST_PAUSE;
 }
 
-void cleanup(void)
+static void cleanup(void)
 {
 }

--- a/testcases/kernel/syscalls/getppid/getppid02.c
+++ b/testcases/kernel/syscalls/getppid/getppid02.c
@@ -46,11 +46,11 @@
 #include "test.h"
 #include "safe_macros.h"
 
-char *TCID = "getppid02";
-int TST_TOTAL = 1;
+static char *TCID = "getppid02";
+static int TST_TOTAL = 1;
 
-void setup(void);
-void cleanup(void);
+static void setup(void);
+static void cleanup(void);
 
 int main(int ac, char **av)
 {
@@ -93,7 +93,7 @@ int main(int ac, char **av)
 	tst_exit();
 }
 
-void setup(void)
+static void setup(void)
 {
 
 	tst_sig(FORK, DEF_HANDLER, cleanup);
@@ -101,6 +101,6 @@ void setup(void)
 	TEST_PAUSE;
 }
 
-void cleanup(void)
+static void cleanup(void)
 {
 }

--- a/testcases/kernel/syscalls/getrusage/getrusage03_child.c
+++ b/testcases/kernel/syscalls/getrusage/getrusage03_child.c
@@ -36,15 +36,15 @@
 #include "test.h"
 #include "safe_macros.h"
 
-char *TCID = "getrusage03_child";
-int TST_TOTAL = 1;
+static char *TCID = "getrusage03_child";
+static int TST_TOTAL = 1;
 
 #define DELTA_MAX	10240
 
 static int opt_consume, opt_grand, opt_show, opt_self, opt_child;
 static char *consume_str, *grand_consume_str, *self_str, *child_str;
 
-option_t child_options[] = {
+static option_t child_options[] = {
 	{"n:", &opt_consume, &consume_str},
 	{"g:", &opt_grand, &grand_consume_str},
 	{"v", &opt_show, NULL},

--- a/testcases/kernel/syscalls/getrusage/getrusage04.c
+++ b/testcases/kernel/syscalls/getrusage/getrusage04.c
@@ -53,8 +53,8 @@
 #include "safe_macros.h"
 #include "lapi/posix_clocks.h"
 
-char *TCID = "getrusage04";
-int TST_TOTAL = 1;
+static char *TCID = "getrusage04";
+static int TST_TOTAL = 1;
 
 #define RECORD_MAX    20
 #define FACTOR_MAX    10
@@ -69,7 +69,7 @@ static int opt_factor;
 static char *factor_str;
 static long factor_nr = 1;
 
-option_t child_options[] = {
+static option_t child_options[] = {
 	{"m:", &opt_factor, &factor_str},
 	{NULL, NULL, NULL}
 };

--- a/testcases/kernel/syscalls/gettid/gettid01.c
+++ b/testcases/kernel/syscalls/gettid/gettid01.c
@@ -33,12 +33,12 @@
 
 #include "test.h"
 
-void setup();
-void cleanup();
+static void setup();
+static void cleanup();
 
-char *TCID = "gettid01";
+static char *TCID = "gettid01";
 
-int TST_TOTAL = 1;
+static int TST_TOTAL = 1;
 
 pid_t my_gettid(void)
 {
@@ -78,7 +78,7 @@ int main(int ac, char **av)
 /*
  * setup() - performs all ONE TIME setup for this test.
  */
-void setup(void)
+static void setup(void)
 {
 
 	tst_sig(NOFORK, DEF_HANDLER, cleanup);
@@ -91,6 +91,6 @@ void setup(void)
  * cleanup() - performs all ONE TIME cleanup for this test at
  *		completion or premature exit.
  */
-void cleanup(void)
+static void cleanup(void)
 {
 }

--- a/testcases/kernel/syscalls/gettimeofday/gettimeofday01.c
+++ b/testcases/kernel/syscalls/gettimeofday/gettimeofday01.c
@@ -41,13 +41,13 @@
 #include <unistd.h>
 #include "lapi/syscalls.h"
 
-char *TCID = "gettimeofday01";
-int TST_TOTAL = 1;
+static char *TCID = "gettimeofday01";
+static int TST_TOTAL = 1;
 
 #if !defined UCLINUX
 
-void cleanup(void);
-void setup(void);
+static void cleanup(void);
+static void setup(void);
 
 int main(int ac, char **av)
 {
@@ -86,7 +86,7 @@ int main(int ac, char **av)
 	tst_exit();
 }
 
-void setup(void)
+static void setup(void)
 {
 
 	tst_sig(NOFORK, DEF_HANDLER, cleanup);
@@ -94,7 +94,7 @@ void setup(void)
 	TEST_PAUSE;
 }
 
-void cleanup(void)
+static void cleanup(void)
 {
 }
 #else

--- a/testcases/kernel/syscalls/getuid/getuid01.c
+++ b/testcases/kernel/syscalls/getuid/getuid01.c
@@ -46,7 +46,7 @@ static void setup(void);
 static void cleanup(void);
 
 TCID_DEFINE(getuid01);
-int TST_TOTAL = 1;
+static int TST_TOTAL = 1;
 
 int main(int ac, char **av)
 {

--- a/testcases/kernel/syscalls/getuid/getuid03.c
+++ b/testcases/kernel/syscalls/getuid/getuid03.c
@@ -31,7 +31,7 @@
 #include "compat_16.h"
 
 TCID_DEFINE(getuid03);
-int TST_TOTAL = 1;
+static int TST_TOTAL = 1;
 
 static void setup(void);
 static void cleanup(void);

--- a/testcases/kernel/syscalls/getxattr/getxattr01.c
+++ b/testcases/kernel/syscalls/getxattr/getxattr01.c
@@ -50,7 +50,7 @@
 #include "test.h"
 #include "safe_macros.h"
 
-char *TCID = "getxattr01";
+static char *TCID = "getxattr01";
 
 #ifdef HAVE_SYS_XATTR_H
 #define XATTR_TEST_KEY "user.testkey"

--- a/testcases/kernel/syscalls/getxattr/getxattr02.c
+++ b/testcases/kernel/syscalls/getxattr/getxattr02.c
@@ -56,7 +56,7 @@
 #include "test.h"
 #include "safe_macros.h"
 
-char *TCID = "getxattr02";
+static char *TCID = "getxattr02";
 
 #ifdef HAVE_SYS_XATTR_H
 #define XATTR_TEST_KEY "user.testkey"

--- a/testcases/kernel/syscalls/getxattr/getxattr03.c
+++ b/testcases/kernel/syscalls/getxattr/getxattr03.c
@@ -44,7 +44,7 @@
 #include "test.h"
 #include "safe_macros.h"
 
-char *TCID = "getxattr03";
+static char *TCID = "getxattr03";
 
 #ifdef HAVE_SYS_XATTR_H
 #define XATTR_TEST_KEY "user.testkey"
@@ -55,7 +55,7 @@ char *TCID = "getxattr03";
 static void setup(void);
 static void cleanup(void);
 
-int TST_TOTAL = 1;
+static int TST_TOTAL = 1;
 
 int main(int argc, char *argv[])
 {

--- a/testcases/kernel/syscalls/kcmp/kcmp.h
+++ b/testcases/kernel/syscalls/kcmp/kcmp.h
@@ -44,7 +44,7 @@ enum kcmp_type {
 
 #if !defined(HAVE_KCMP)
 
-int kcmp(int pid1, int pid2, int type, int fd1, int fd2)
+static int kcmp(int pid1, int pid2, int type, int fd1, int fd2)
 {
 	return tst_syscall(__NR_kcmp, pid1, pid2, type, fd1, fd2);
 }

--- a/testcases/kernel/syscalls/kill/kill01.c
+++ b/testcases/kernel/syscalls/kill/kill01.c
@@ -61,12 +61,12 @@
 #include <errno.h>
 #include <sys/wait.h>
 
-void cleanup(void);
-void setup(void);
-void do_child(void);
+static void cleanup(void);
+static void setup(void);
+static void do_child(void);
 
-char *TCID = "kill01";
-int TST_TOTAL = 1;
+static char *TCID = "kill01";
+static int TST_TOTAL = 1;
 
 #define TEST_SIG SIGKILL
 
@@ -134,7 +134,7 @@ int main(int ac, char **av)
 /*
  * do_child()
  */
-void do_child(void)
+static void do_child(void)
 {
 	int exno = 1;
 
@@ -145,7 +145,7 @@ void do_child(void)
 /*
  * setup() - performs all ONE TIME setup for this test
  */
-void setup(void)
+static void setup(void)
 {
 
 	TEST_PAUSE;
@@ -155,7 +155,7 @@ void setup(void)
  * cleanup() - performs all the ONE TIME cleanup for this test at completion
  * or premature exit.
  */
-void cleanup(void)
+static void cleanup(void)
 {
 
 }

--- a/testcases/kernel/syscalls/kill/kill03.c
+++ b/testcases/kernel/syscalls/kill/kill03.c
@@ -61,12 +61,12 @@
 #include <errno.h>
 #include <sys/wait.h>
 
-void cleanup(void);
-void setup(void);
-void do_child(void);
+static void cleanup(void);
+static void setup(void);
+static void do_child(void);
 
-char *TCID = "kill03";
-int TST_TOTAL = 1;
+static char *TCID = "kill03";
+static int TST_TOTAL = 1;
 
 #define TEST_SIG 2000
 
@@ -138,7 +138,7 @@ int main(int ac, char **av)
 /*
  * do_child()
  */
-void do_child(void)
+static void do_child(void)
 {
 	int exno = 1;
 
@@ -149,7 +149,7 @@ void do_child(void)
 /*
  * setup() - performs all ONE TIME setup for this test
  */
-void setup(void)
+static void setup(void)
 {
 
 	TEST_PAUSE;
@@ -159,7 +159,7 @@ void setup(void)
  * cleanup() - performs all the ONE TIME cleanup for this test at completion
  * or premature exit.
  */
-void cleanup(void)
+static void cleanup(void)
 {
 
 }

--- a/testcases/kernel/syscalls/kill/kill04.c
+++ b/testcases/kernel/syscalls/kill/kill04.c
@@ -61,12 +61,12 @@
 #include <errno.h>
 #include <sys/wait.h>
 
-void cleanup(void);
-void setup(void);
-void do_child(void);
+static void cleanup(void);
+static void setup(void);
+static void do_child(void);
 
-char *TCID = "kill04";
-int TST_TOTAL = 1;
+static char *TCID = "kill04";
+static int TST_TOTAL = 1;
 
 #define TEST_SIG SIGKILL
 
@@ -117,7 +117,7 @@ int main(int ac, char **av)
 /*
  * setup() - performs all ONE TIME setup for this test
  */
-void setup(void)
+static void setup(void)
 {
 
 	TEST_PAUSE;
@@ -127,7 +127,7 @@ void setup(void)
  * cleanup() - performs all the ONE TIME cleanup for this test at completion
  * or premature exit.
  */
-void cleanup(void)
+static void cleanup(void)
 {
 
 }

--- a/testcases/kernel/syscalls/kill/kill09.c
+++ b/testcases/kernel/syscalls/kill/kill09.c
@@ -118,15 +118,15 @@
 
 #include "test.h"
 
-void setup();
-void cleanup();
-void alarm_handler(int sig);
-void do_child();
+static void setup();
+static void cleanup();
+static void alarm_handler(int sig);
+static void do_child();
 
-char *TCID = "kill09";
-int TST_TOTAL = 1;
+static char *TCID = "kill09";
+static int TST_TOTAL = 1;
 
-int fork_pid;
+static int fork_pid;
 
 int main(int ac, char **av)
 {
@@ -176,7 +176,7 @@ int main(int ac, char **av)
 	tst_exit();
 }
 
-void do_child(void)
+static void do_child(void)
 {
 	/*
 	 * Setup alarm signal if we don't get the signal to prevent this process
@@ -188,7 +188,7 @@ void do_child(void)
 	exit(1);
 }
 
-void setup(void)
+static void setup(void)
 {
 
 	tst_sig(NOFORK, DEF_HANDLER, cleanup);
@@ -199,11 +199,11 @@ void setup(void)
 
 }
 
-void cleanup(void)
+static void cleanup(void)
 {
 }
 
-void alarm_handler(int sig)
+static void alarm_handler(int sig)
 {
 	exit(8);
 }

--- a/testcases/kernel/syscalls/kill/kill12.c
+++ b/testcases/kernel/syscalls/kill/kill12.c
@@ -51,25 +51,26 @@
 #define FAILED 0
 #define PASSED 1
 
-char *TCID = "kill12";
+static char *TCID = "kill12";
 
-int local_flag = PASSED;
-int block_number;
-FILE *temp;
-int TST_TOTAL = 1;
+static int local_flag = PASSED;
+static int block_number;
+static FILE *temp;
+static int TST_TOTAL = 1;
 static int sig;
 
-int anyfail();
-int blenter();
-int instress();
-void setup();
-void terror();
-void fail_exit();
-void ok_exit();
-int forkfail();
-void do_child();
+static int anyfail();
+static int blenter();
+static int instress();
+static void setup();
+static void terror();
+static void fail_exit();
+static void ok_exit();
+static int forkfail();
+static void do_child();
+static void chsig();
 
-int chflag;
+static int chflag;
 
 int main(int argc, char **argv)
 {
@@ -77,7 +78,6 @@ int main(int argc, char **argv)
 	int nsig, exno, nexno, status;
 	int ret_val = 0;
 	int core;
-	void chsig();
 
 	tst_parse_opts(argc, argv, NULL, NULL);
 
@@ -181,12 +181,12 @@ int main(int argc, char **argv)
 	tst_exit();
 }
 
-void chsig(void)
+static void chsig(void)
 {
 	chflag++;
 }
 
-int anyfail(void)
+static int anyfail(void)
 {
 	(local_flag == FAILED) ? tst_resm(TFAIL,
 					  "Test failed") : tst_resm(TPASS,
@@ -194,7 +194,7 @@ int anyfail(void)
 	tst_exit();
 }
 
-void do_child(void)
+static void do_child(void)
 {
 	int exno = 1;
 
@@ -206,31 +206,31 @@ void do_child(void)
 	exit(exno);
 }
 
-void setup(void)
+static void setup(void)
 {
 	temp = stderr;
 }
 
-int blenter(void)
+static int blenter(void)
 {
 	//tst_resm(TINFO, "Enter block %d", block_number);
 	local_flag = PASSED;
 	return 0;
 }
 
-void terror(char *message)
+static void terror(char *message)
 {
 	tst_resm(TBROK, "Reason: %s:%s", message, strerror(errno));
 }
 
-void fail_exit(void)
+static void fail_exit(void)
 {
 	local_flag = FAILED;
 	anyfail();
 
 }
 
-int forkfail(void)
+static int forkfail(void)
 {
 	tst_brkm(TBROK, NULL, "FORK FAILED - terminating test.");
 }

--- a/testcases/kernel/syscalls/lchown/lchown01.c
+++ b/testcases/kernel/syscalls/lchown/lchown01.c
@@ -48,7 +48,7 @@
 #define SFILE		"slink_file"
 
 TCID_DEFINE(lchown01);
-int TST_TOTAL = 5;
+static int TST_TOTAL = 5;
 
 struct test_case_t {
 	char *desc;

--- a/testcases/kernel/syscalls/lchown/lchown02.c
+++ b/testcases/kernel/syscalls/lchown/lchown02.c
@@ -72,7 +72,7 @@
 #define SFILE3		"t_file/sfile"
 
 TCID_DEFINE(lchown02);
-int TST_TOTAL = 7;
+static int TST_TOTAL = 7;
 
 static void setup(void);
 static void cleanup(void);

--- a/testcases/kernel/syscalls/lchown/lchown03.c
+++ b/testcases/kernel/syscalls/lchown/lchown03.c
@@ -58,7 +58,7 @@ static struct test_case_t {
 };
 
 TCID_DEFINE(lchown03);
-int TST_TOTAL = ARRAY_SIZE(test_cases);
+static int TST_TOTAL = ARRAY_SIZE(test_cases);
 
 static void setup(void);
 static void lchown_verify(const struct test_case_t *);

--- a/testcases/kernel/syscalls/link/link02.c
+++ b/testcases/kernel/syscalls/link/link02.c
@@ -49,8 +49,8 @@
 static void setup(void);
 static void cleanup(void);
 
-char *TCID = "link02";
-int TST_TOTAL = 1;
+static char *TCID = "link02";
+static int TST_TOTAL = 1;
 
 #define OLDPATH "oldpath"
 #define NEWPATH "newpath"

--- a/testcases/kernel/syscalls/link/link03.c
+++ b/testcases/kernel/syscalls/link/link03.c
@@ -51,8 +51,8 @@ static void setup(void);
 static void help(void);
 static void cleanup(void);
 
-char *TCID = "link03";
-int TST_TOTAL = 2;
+static char *TCID = "link03";
+static int TST_TOTAL = 2;
 
 #define BASENAME	"lkfile"
 
@@ -60,7 +60,7 @@ static char fname[255];
 static int nlinks = 0;
 static char *links_arg;
 
-option_t options[] = {
+static option_t options[] = {
 	{"N:", NULL, &links_arg},
 	{NULL, NULL, NULL}
 };

--- a/testcases/kernel/syscalls/link/link04.c
+++ b/testcases/kernel/syscalls/link/link04.c
@@ -53,7 +53,7 @@
 
 static char longpath[PATH_MAX + 2];
 
-struct test_case_t {
+static struct test_case_t {
 	char *file1;
 	char *desc1;
 	char *file2;
@@ -81,8 +81,8 @@ struct test_case_t {
 	{"regfile", "regfile", "regfile2", "regfile2", EEXIST},
 };
 
-char *TCID = "link04";
-int TST_TOTAL = ARRAY_SIZE(test_cases);
+static char *TCID = "link04";
+static int TST_TOTAL = ARRAY_SIZE(test_cases);
 
 static void setup(void);
 static void cleanup(void);

--- a/testcases/kernel/syscalls/link/link05.c
+++ b/testcases/kernel/syscalls/link/link05.c
@@ -50,8 +50,8 @@ static void setup(void);
 static void cleanup(void);
 static void help(void);
 
-char *TCID = "link05";
-int TST_TOTAL = 1;
+static char *TCID = "link05";
+static int TST_TOTAL = 1;
 
 #define BASENAME	"lkfile"
 
@@ -59,7 +59,7 @@ static char fname[255];
 
 static char *links_arg;
 
-option_t options[] = {
+static option_t options[] = {
 	{"N:", NULL, &links_arg},
 	{NULL, NULL, NULL}
 };

--- a/testcases/kernel/syscalls/link/link06.c
+++ b/testcases/kernel/syscalls/link/link06.c
@@ -45,8 +45,8 @@
 static void setup(void);
 static void cleanup(void);
 
-char *TCID = "link06";
-int TST_TOTAL = 1;
+static char *TCID = "link06";
+static int TST_TOTAL = 1;
 
 #define OLDPATH "oldpath"
 #define NEWPATH "newpath"

--- a/testcases/kernel/syscalls/link/link07.c
+++ b/testcases/kernel/syscalls/link/link07.c
@@ -48,8 +48,8 @@
 static void setup(void);
 static void cleanup(void);
 
-char *TCID = "link07";
-int TST_TOTAL = 1;
+static char *TCID = "link07";
+static int TST_TOTAL = 1;
 
 int main(int ac, char **av)
 {

--- a/testcases/kernel/syscalls/linkat/linkat02.c
+++ b/testcases/kernel/syscalls/linkat/linkat02.c
@@ -77,8 +77,8 @@ static struct test_struct {
 	{TEST_EMLINK, TEST_EMLINK2, 0, EMLINK, NULL, NULL},
 };
 
-char *TCID = "linkat02";
-int TST_TOTAL = ARRAY_SIZE(test_cases);
+static char *TCID = "linkat02";
+static int TST_TOTAL = ARRAY_SIZE(test_cases);
 
 static struct passwd *ltpuser;
 static void linkat_verify(const struct test_struct *);

--- a/testcases/kernel/syscalls/mallopt/mallopt01.c
+++ b/testcases/kernel/syscalls/mallopt/mallopt01.c
@@ -53,15 +53,15 @@
 #define PASSED 1
 #define MAX_FAST_SIZE	(80 * sizeof(size_t) / 4)
 
-int local_flag = PASSED;
+static int local_flag = PASSED;
 
-char *TCID = "mallopt01";
-int block_number;
-FILE *temp;
-int TST_TOTAL = 6;
+static char *TCID = "mallopt01";
+static int block_number;
+static FILE *temp;
+static int TST_TOTAL = 6;
 extern int tst_COUNT;		/* Test Case counter for tst_routines */
 
-void printinfo();
+static void printinfo();
 
 #if defined(__GLIBC__)
 struct mallinfo info;
@@ -131,7 +131,7 @@ int main(int argc, char *argv[])
 	tst_exit();
 }
 
-void printinfo(void)
+static void printinfo(void)
 {
 
 	fprintf(stderr, "mallinfo structure:\n");

--- a/testcases/kernel/syscalls/membarrier/membarrier01.c
+++ b/testcases/kernel/syscalls/membarrier/membarrier01.c
@@ -40,7 +40,7 @@ struct test_case {
 	int change_kernver[3];	/* kernel version having diff expected errno */
 };
 
-struct test_case tc[] = {
+static struct test_case tc[] = {
 	{
 	 /*
 	  * case 00) invalid cmd

--- a/testcases/kernel/syscalls/memcmp/memcmp01.c
+++ b/testcases/kernel/syscalls/memcmp/memcmp01.c
@@ -41,7 +41,7 @@
 
 #include "test.h"
 
-char *TCID = "memcmp1";
+static char *TCID = "memcmp1";
 
 #undef  BSIZE
 #define BSIZE	4096
@@ -49,22 +49,22 @@ char *TCID = "memcmp1";
 #define FAILED 0
 #define PASSED 1
 
-char buf[BSIZE];
+static char buf[BSIZE];
 
-int local_flag = PASSED;
+static int local_flag = PASSED;
 int block_number;
-FILE *temp;
-int TST_TOTAL = 2;
-int anyfail();
-int blenter();
-int blexit();
-int instress();
+static FILE *temp;
+static int TST_TOTAL = 2;
+static int anyfail();
+static int blenter();
+static int blexit();
+static int instress();
 
-void setup();
+static void setup();
 
-void clearit();
-void fill(char *str);
-int checkit(char *str);
+static void clearit();
+static void fill(char *str);
+static int checkit(char *str);
 
 int main(int argc, char *argv[])
 {
@@ -187,7 +187,7 @@ int main(int argc, char *argv[])
 	tst_exit();
 }
 
-void clearit(void)
+static void clearit(void)
 {
 	register int i;
 
@@ -195,14 +195,14 @@ void clearit(void)
 		buf[i] = 0;
 }
 
-void fill(char *str)
+static void fill(char *str)
 {
 	register int i;
 	for (i = 0; i < LEN; i++)
 		*str++ = 'a';
 }
 
-int checkit(char *str)
+static int checkit(char *str)
 {
 	register int i;
 	for (i = 0; i < LEN; i++)
@@ -212,23 +212,23 @@ int checkit(char *str)
 	return (0);
 }
 
-int anyfail(void)
+static int anyfail(void)
 {
 	tst_exit();
 }
 
-void setup(void)
+static void setup(void)
 {
 	temp = stderr;
 }
 
-int blenter(void)
+static int blenter(void)
 {
 	local_flag = PASSED;
 	return 0;
 }
 
-int blexit(void)
+static int blexit(void)
 {
 	(local_flag == FAILED) ? tst_resm(TFAIL,
 					  "Test failed") : tst_resm(TPASS,

--- a/testcases/kernel/syscalls/memcpy/memcpy01.c
+++ b/testcases/kernel/syscalls/memcpy/memcpy01.c
@@ -46,7 +46,7 @@
 
 #include "test.h"
 
-char *TCID = "memcpy1";
+static char *TCID = "memcpy1";
 
 #undef  BSIZE
 #define BSIZE	4096
@@ -54,21 +54,21 @@ char *TCID = "memcpy1";
 #define FAILED 0
 #define PASSED 1
 
-int local_flag = PASSED;
-int block_number;
-FILE *temp;
-int TST_TOTAL = 1;
-char buf[BSIZE];
+static int local_flag = PASSED;
+static int block_number;
+static FILE *temp;
+static int TST_TOTAL = 1;
+static char buf[BSIZE];
 
 
-int anyfail();
-int blenter();
-int blexit();
+static int anyfail();
+static int blenter();
+static int blexit();
 
-void setup();
-void clearit();
-void fill(char *str);
-int checkit(char *str);
+static void setup();
+static void clearit();
+static void fill(char *str);
+static int checkit(char *str);
 
 int main(int argc, char *argv[])
 {
@@ -136,7 +136,7 @@ int main(int argc, char *argv[])
 	tst_exit();
 }
 
-void clearit(void)
+static void clearit(void)
 {
 	register int i;
 
@@ -144,14 +144,14 @@ void clearit(void)
 		buf[i] = 0;
 }
 
-void fill(char *str)
+static void fill(char *str)
 {
 	register int i;
 	for (i = 0; i < LEN; i++)
 		*str++ = 'a';
 }
 
-int checkit(char *str)
+static int checkit(char *str)
 {
 	register int i;
 	for (i = 0; i < LEN; i++)
@@ -161,7 +161,7 @@ int checkit(char *str)
 	return (0);
 }
 
-int anyfail(void)
+static int anyfail(void)
 {
 	(local_flag == FAILED) ? tst_resm(TFAIL,
 					  "Test failed") : tst_resm(TPASS,
@@ -169,18 +169,18 @@ int anyfail(void)
 	tst_exit();
 }
 
-void setup(void)
+static void setup(void)
 {
 	temp = stderr;
 }
 
-int blenter(void)
+static int blenter(void)
 {
 	local_flag = PASSED;
 	return 0;
 }
 
-int blexit(void)
+static int blexit(void)
 {
 	(local_flag == FAILED) ? tst_resm(TFAIL,
 					  "Test failed") : tst_resm(TPASS,

--- a/testcases/kernel/syscalls/memmap/mem03.c
+++ b/testcases/kernel/syscalls/memmap/mem03.c
@@ -60,11 +60,11 @@
 static void setup();
 static void cleanup();
 
-char *TCID = "mem03";
-int TST_TOTAL = 1;
+static char *TCID = "mem03";
+static int TST_TOTAL = 1;
 
-int f1 = -1, f2 = -1;
-char *mm1 = NULL, *mm2 = NULL;
+static int f1 = -1, f2 = -1;
+static char *mm1 = NULL, *mm2 = NULL;
 
 /*--------------------------------------------------------------------*/
 int main(void)
@@ -144,7 +144,7 @@ int main(void)
 /*
  * setup() - performs all ONE TIME setup for this test
  */
-void setup(void)
+static void setup(void)
 {
 	/*
 	 * Create a temporary directory and cd into it.
@@ -156,7 +156,7 @@ void setup(void)
  * cleanup() - performs all the ONE TIME cleanup for this test at completion
  * 	       or premature exit.
  */
-void cleanup(void)
+static void cleanup(void)
 {
 	if (mm1)
 		munmap(mm1, 64);

--- a/testcases/kernel/syscalls/memset/memset01.c
+++ b/testcases/kernel/syscalls/memset/memset01.c
@@ -41,7 +41,7 @@
 
 #include "test.h"
 
-char *TCID = "memset01";
+static char *TCID = "memset01";
 
 #undef BSIZE
 #define BSIZE	4096
@@ -49,14 +49,14 @@ char *TCID = "memset01";
 #define FAILED 0
 #define PASSED 1
 
-char buf[BSIZE];
+static char buf[BSIZE];
 
-int local_flag = PASSED;
-int block_number;
-int TST_TOTAL = 1;
+static int local_flag = PASSED;
+static int block_number;
+static int TST_TOTAL = 1;
 
-void fill(void);
-int checkit(char *str);
+static void fill(void);
+static int checkit(char *str);
 
 int main(int argc, char *argv[])
 {
@@ -97,14 +97,14 @@ int main(int argc, char *argv[])
 	tst_exit();
 }
 
-void fill(void)
+static void fill(void)
 {
 	register int i;
 	for (i = 0; i < BSIZE; i++)
 		buf[i] = 'a';
 }
 
-int checkit(char *str)
+static int checkit(char *str)
 {
 	register int i = 0;
 

--- a/testcases/kernel/syscalls/mkdir/mkdir05.c
+++ b/testcases/kernel/syscalls/mkdir/mkdir05.c
@@ -47,7 +47,7 @@ static void verify_mkdir(void)
 	SAFE_RMDIR(TESTDIR);
 }
 
-void setup(void)
+static void setup(void)
 {
 	struct passwd *pw;
 

--- a/testcases/kernel/syscalls/mkdir/mkdir09.c
+++ b/testcases/kernel/syscalls/mkdir/mkdir09.c
@@ -56,24 +56,24 @@
 #define MODE_RWX	07770
 #define DIR_NAME	"./X.%d"
 
-char *TCID = "mkdir09";
-int TST_TOTAL = 1;
+static char *TCID = "mkdir09";
+static int TST_TOTAL = 1;
 
-char testdir[MAXPATHLEN];
-int parent_pid, sigchld, sigterm, jump;
-void term(int sig);
-void chld(int sig);
-int *pidlist, child_count;
-jmp_buf env_buf;
+static char testdir[MAXPATHLEN];
+static int parent_pid, sigchld, sigterm, jump;
+static void term(int sig);
+static void chld(int sig);
+static int *pidlist, child_count;
+static jmp_buf env_buf;
 
-int getchild(int group, int child, int children);
-int dochild1(void);
-int dochild2(void);
-int dochild3(int group);
-int massmurder(void);
-int runtest(void);
-void setup(void);
-void cleanup(void);
+static int getchild(int group, int child, int children);
+static int dochild1(void);
+static int dochild2(void);
+static int dochild3(int group);
+static int massmurder(void);
+static int runtest(void);
+static void setup(void);
+static void cleanup(void);
 
 static int child_groups = 2;
 static int test_time = 5;
@@ -129,7 +129,7 @@ int main(int argc, char *argv[])
 	tst_exit();
 }
 
-int runtest(void)
+static int runtest(void)
 {
 	int i, j;
 	int count, child, status;
@@ -261,7 +261,7 @@ int runtest(void)
 	return 0;
 }
 
-int getchild(int group, int child, int children)
+static int getchild(int group, int child, int children)
 {
 	int pid;
 
@@ -295,7 +295,7 @@ int getchild(int group, int child, int children)
 	return 0;
 }
 
-void term(int sig)
+static void term(int sig)
 {
 	/* Routine to handle SIGTERM signal. */
 
@@ -308,7 +308,7 @@ void term(int sig)
 	}
 }
 
-void chld(int sig)
+static void chld(int sig)
 {
 	/* Routine to handle SIGCHLD signal. */
 
@@ -318,7 +318,7 @@ void chld(int sig)
 	}
 }
 
-int dochild1(void)
+static int dochild1(void)
 {
 	/* Child routine which attempts to create directories in the test
 	 * directory that already exist. Runs until a SIGTERM signal is
@@ -353,7 +353,7 @@ int dochild1(void)
 	exit(0);
 }
 
-int dochild2(void)
+static int dochild2(void)
 {
 	/* Child routine which attempts to remove directories from the
 	 * test directory which do not exist. Runs until a SIGTERM
@@ -387,7 +387,7 @@ int dochild2(void)
 	return 0;
 }
 
-int dochild3(int group)
+static int dochild3(int group)
 {
 	/* Child routine which creates and deletes directories in the
 	 * test directory. Runs until a SIGTERM signal is received, then
@@ -430,7 +430,7 @@ int dochild3(int group)
 	exit(0);
 }
 
-int massmurder(void)
+static int massmurder(void)
 {
 	register int j;
 	for (j = 0; j < child_count; j++) {
@@ -445,7 +445,7 @@ int massmurder(void)
 	return 0;
 }
 
-void setup(void)
+static void setup(void)
 {
 	tst_sig(NOFORK, DEF_HANDLER, cleanup);
 
@@ -454,7 +454,7 @@ void setup(void)
 	tst_tmpdir();
 }
 
-void cleanup(void)
+static void cleanup(void)
 {
 	tst_rmdir();
 }

--- a/testcases/kernel/syscalls/mkdirat/mkdirat01.c
+++ b/testcases/kernel/syscalls/mkdirat/mkdirat01.c
@@ -60,8 +60,8 @@ static struct test_case {
 	{&fd_invalid, relpath, -1, EBADF},
 };
 
-char *TCID = "mkdirat01";
-int TST_TOTAL = ARRAY_SIZE(test_cases);
+static char *TCID = "mkdirat01";
+static int TST_TOTAL = ARRAY_SIZE(test_cases);
 
 static void verify_mkdirat(struct test_case *test)
 {

--- a/testcases/kernel/syscalls/mknod/mknod01.c
+++ b/testcases/kernel/syscalls/mknod/mknod01.c
@@ -47,11 +47,11 @@
 static void setup(void);
 static void cleanup(void);
 
-char *TCID = "mknod01";
+static char *TCID = "mknod01";
 
 #define PATH "test_node"
 
-int tcases[] = {		/* modes to give nodes created (1 per text case) */
+static int tcases[] = {		/* modes to give nodes created (1 per text case) */
 	S_IFREG | 0777,		/* ordinary file with mode 0777 */
 	S_IFIFO | 0777,		/* fifo special with mode 0777 */
 	S_IFCHR | 0777,		/* character special with mode 0777 */
@@ -62,7 +62,7 @@ int tcases[] = {		/* modes to give nodes created (1 per text case) */
 	S_IFREG | 06700,	/* ordinary file with mode 06700 (sgid & suid) */
 };
 
-int TST_TOTAL = ARRAY_SIZE(tcases);
+static int TST_TOTAL = ARRAY_SIZE(tcases);
 
 int main(int ac, char **av)
 {
@@ -107,7 +107,7 @@ int main(int ac, char **av)
 	tst_exit();
 }
 
-void setup(void)
+static void setup(void)
 {
 	tst_require_root();
 	tst_sig(NOFORK, DEF_HANDLER, cleanup);
@@ -117,7 +117,7 @@ void setup(void)
 	tst_tmpdir();
 }
 
-void cleanup(void)
+static void cleanup(void)
 {
 	tst_rmdir();
 }

--- a/testcases/kernel/syscalls/mknod/mknod02.c
+++ b/testcases/kernel/syscalls/mknod/mknod02.c
@@ -88,19 +88,19 @@
 #define DIR_TEMP	"testdir_2"
 #define TNODE		"tnode_%d"
 
-struct stat buf;		/* struct. to hold stat(2) o/p contents */
-struct passwd *user1;		/* struct. to hold getpwnam(3) o/p contents */
+static struct stat buf;		/* struct. to hold stat(2) o/p contents */
+static struct passwd *user1;		/* struct. to hold getpwnam(3) o/p contents */
 
-char *TCID = "mknod02";
-int TST_TOTAL = 1;
-char node_name[PATH_MAX];	/* buffer to hold node name created */
+static char *TCID = "mknod02";
+static int TST_TOTAL = 1;
+static char node_name[PATH_MAX];	/* buffer to hold node name created */
 
-gid_t group1_gid, group2_gid, mygid;	/* user and process group id's */
-uid_t save_myuid, user1_uid;	/* user and process user id's */
-pid_t mypid;			/* process id */
+static gid_t group1_gid, group2_gid, mygid;	/* user and process group id's */
+static uid_t save_myuid, user1_uid;	/* user and process user id's */
+static pid_t mypid;			/* process id */
 
-void setup();			/* setup function for the test */
-void cleanup();			/* cleanup function for the test */
+static void setup();			/* setup function for the test */
+static void cleanup();			/* cleanup function for the test */
 
 int main(int ac, char **av)
 {
@@ -194,7 +194,7 @@ int main(int ac, char **av)
  *	of test directory to ltp user and process.
  *	Set the effective uid/gid of the process to that of ltp user.
  */
-void setup(void)
+static void setup(void)
 {
 	tst_require_root();
 
@@ -284,7 +284,7 @@ void setup(void)
  *	created during setup().
  *	Exit the test program with normal exit code.
  */
-void cleanup(void)
+static void cleanup(void)
 {
 
 	/*

--- a/testcases/kernel/syscalls/mknod/mknod03.c
+++ b/testcases/kernel/syscalls/mknod/mknod03.c
@@ -88,19 +88,19 @@
 #define DIR_TEMP	"testdir_3"
 #define TNODE		"tnode_%d"
 
-struct stat buf;		/* struct. to hold stat(2) o/p contents */
-struct passwd *user1;		/* struct. to hold getpwnam(3) o/p contents */
+static struct stat buf;		/* struct. to hold stat(2) o/p contents */
+static struct passwd *user1;		/* struct. to hold getpwnam(3) o/p contents */
 
-char *TCID = "mknod03";
-int TST_TOTAL = 1;
-char node_name[PATH_MAX];	/* buffer to hold node name created */
+static char *TCID = "mknod03";
+static int TST_TOTAL = 1;
+static char node_name[PATH_MAX];	/* buffer to hold node name created */
 
-gid_t group1_gid, group2_gid, mygid;	/* user and process group id's */
-uid_t save_myuid, user1_uid;	/* user and process user id's */
-pid_t mypid;			/* process id */
+static gid_t group1_gid, group2_gid, mygid;	/* user and process group id's */
+static uid_t save_myuid, user1_uid;	/* user and process user id's */
+static pid_t mypid;			/* process id */
 
-void setup();			/* setup function for the test */
-void cleanup();			/* cleanup function for the test */
+static void setup();			/* setup function for the test */
+static void cleanup();			/* cleanup function for the test */
 
 int main(int ac, char **av)
 {
@@ -191,7 +191,7 @@ int main(int ac, char **av)
  *	to set group id bit on it.
  *	Set the effective uid/gid of the process to that of guest user.
  */
-void setup(void)
+static void setup(void)
 {
 	tst_require_root();
 
@@ -279,7 +279,7 @@ void setup(void)
  *	created during setup().
  *	Exit the test program with normal exit code.
  */
-void cleanup(void)
+static void cleanup(void)
 {
 
 	/*

--- a/testcases/kernel/syscalls/mknod/mknod04.c
+++ b/testcases/kernel/syscalls/mknod/mknod04.c
@@ -88,19 +88,19 @@
 #define DIR_TEMP	"testdir_4"
 #define TNODE		"tnode_%d"
 
-struct stat buf;		/* struct. to hold stat(2) o/p contents */
-struct passwd *user1;		/* struct. to hold getpwnam(3) o/p contents */
+static struct stat buf;		/* struct. to hold stat(2) o/p contents */
+static struct passwd *user1;		/* struct. to hold getpwnam(3) o/p contents */
 
-char *TCID = "mknod04";
-int TST_TOTAL = 1;
-char node_name[PATH_MAX];	/* buffer to hold node name created */
+static char *TCID = "mknod04";
+static int TST_TOTAL = 1;
+static char node_name[PATH_MAX];	/* buffer to hold node name created */
 
-gid_t group1_gid, group2_gid, mygid;	/* user and process group id's */
-uid_t save_myuid, user1_uid;	/* user and process user id's */
-pid_t mypid;			/* process id */
+static gid_t group1_gid, group2_gid, mygid;	/* user and process group id's */
+static uid_t save_myuid, user1_uid;	/* user and process user id's */
+static pid_t mypid;			/* process id */
 
-void setup();			/* setup function for the test */
-void cleanup();			/* cleanup function for the test */
+static void setup();			/* setup function for the test */
+static void cleanup();			/* cleanup function for the test */
 
 int main(int ac, char **av)
 {
@@ -195,7 +195,7 @@ int main(int ac, char **av)
  *	to set group-id bit on it.
  *	Set the effective uid/gid of the process to that of guest user.
  */
-void setup(void)
+static void setup(void)
 {
 	tst_require_root();
 
@@ -284,7 +284,7 @@ void setup(void)
  *	created during setup().
  *	Exit the test program with normal exit code.
  */
-void cleanup(void)
+static void cleanup(void)
 {
 
 	/*

--- a/testcases/kernel/syscalls/mknod/mknod05.c
+++ b/testcases/kernel/syscalls/mknod/mknod05.c
@@ -88,19 +88,19 @@
 #define DIR_TEMP	"testdir_5"
 #define TNODE		"tnode_%d"
 
-struct stat buf;		/* struct. to hold stat(2) o/p contents */
-struct passwd *user1;		/* struct. to hold getpwnam(3) o/p contents */
+static struct stat buf;		/* struct. to hold stat(2) o/p contents */
+static struct passwd *user1;		/* struct. to hold getpwnam(3) o/p contents */
 
-char *TCID = "mknod05";
-int TST_TOTAL = 1;
+static char *TCID = "mknod05";
+static int TST_TOTAL = 1;
 char node_name[PATH_MAX];	/* buffer to hold node name created */
 
-gid_t group1_gid, group2_gid, mygid;	/* user and process group id's */
-uid_t save_myuid, user1_uid;	/* user and process user id's */
-pid_t mypid;			/* process id */
+static gid_t group1_gid, group2_gid, mygid;	/* user and process group id's */
+static uid_t save_myuid, user1_uid;	/* user and process user id's */
+static pid_t mypid;			/* process id */
 
-void setup();			/* setup function for the test */
-void cleanup();			/* cleanup function for the test */
+static void setup();			/* setup function for the test */
+static void cleanup();			/* cleanup function for the test */
 
 int main(int ac, char **av)
 {
@@ -192,7 +192,7 @@ int main(int ac, char **av)
  *	of test directory to guest user and process, change mode permissions
  *	to set group id bit on it.
  */
-void setup(void)
+static void setup(void)
 {
 	tst_require_root();
 
@@ -260,7 +260,7 @@ void setup(void)
  *	created during setup().
  *	Exit the test program with normal exit code.
  */
-void cleanup(void)
+static void cleanup(void)
 {
 
 	tst_rmdir();

--- a/testcases/kernel/syscalls/mknod/mknod07.c
+++ b/testcases/kernel/syscalls/mknod/mknod07.c
@@ -78,8 +78,8 @@ static struct test_case_t {
 	{ elooppathname, FIFO_MODE, ELOOP },
 };
 
-char *TCID = "mknod07";
-int TST_TOTAL = ARRAY_SIZE(test_cases);
+static char *TCID = "mknod07";
+static int TST_TOTAL = ARRAY_SIZE(test_cases);
 
 static void setup(void);
 static void mknod_verify(const struct test_case_t *test_case);

--- a/testcases/kernel/syscalls/mknodat/mknodat01.c
+++ b/testcases/kernel/syscalls/mknodat/mknodat01.c
@@ -66,8 +66,8 @@ static struct test_case {
 	{&fd_atcwd, testfile, 0, 0}
 };
 
-char *TCID = "mknodat01";
-int TST_TOTAL = ARRAY_SIZE(test_cases);
+static char *TCID = "mknodat01";
+static int TST_TOTAL = ARRAY_SIZE(test_cases);
 
 static dev_t dev;
 

--- a/testcases/kernel/syscalls/mknodat/mknodat02.c
+++ b/testcases/kernel/syscalls/mknodat/mknodat02.c
@@ -79,8 +79,8 @@ static struct test_case_t {
 
 static void mknodat_verify(struct test_case_t *tc);
 
-char *TCID = "mknodat";
-int TST_TOTAL = ARRAY_SIZE(test_cases);
+static char *TCID = "mknodat";
+static int TST_TOTAL = ARRAY_SIZE(test_cases);
 
 int main(int ac, char **av)
 {

--- a/testcases/kernel/syscalls/mlock/mlock02.c
+++ b/testcases/kernel/syscalls/mlock/mlock02.c
@@ -41,7 +41,7 @@
 #include "test.h"
 #include "safe_macros.h"
 
-char *TCID = "mlock02";
+static char *TCID = "mlock02";
 
 #if !defined(UCLINUX)
 
@@ -58,7 +58,7 @@ static struct passwd *ltpuser;
 
 static void (*test_func[])(void) = { test_enomem1, test_enomem2, test_eperm };
 
-int TST_TOTAL = ARRAY_SIZE(test_func);
+static int TST_TOTAL = ARRAY_SIZE(test_func);
 
 int main(int ac, char **av)
 {

--- a/testcases/kernel/syscalls/mlock/mlock03.c
+++ b/testcases/kernel/syscalls/mlock/mlock03.c
@@ -40,8 +40,8 @@
 
 #define KB 1024
 
-char *TCID = "mlock03";
-int TST_TOTAL = 1;
+static char *TCID = "mlock03";
+static int TST_TOTAL = 1;
 
 static void setup(void);
 static void cleanup(void);

--- a/testcases/kernel/syscalls/mlock/mlock04.c
+++ b/testcases/kernel/syscalls/mlock/mlock04.c
@@ -34,8 +34,8 @@
 #include "safe_macros.h"
 #include "config.h"
 
-char *TCID = "mlock04";
-int TST_TOTAL = 1;
+static char *TCID = "mlock04";
+static int TST_TOTAL = 1;
 
 #include <sys/mman.h>
 #include <stdio.h>
@@ -46,8 +46,8 @@ int TST_TOTAL = 1;
 #include <unistd.h>
 #include <sys/types.h>
 
-int fd, file_len = 40960;
-char *testfile = "test_mlock";
+static int fd, file_len = 40960;
+static char *testfile = "test_mlock";
 
 static void setup(void);
 static void cleanup(void);

--- a/testcases/kernel/syscalls/mmap/mmap02.c
+++ b/testcases/kernel/syscalls/mmap/mmap02.c
@@ -47,8 +47,8 @@
 
 #define TEMPFILE	"mmapfile"
 
-char *TCID = "mmap02";
-int TST_TOTAL = 1;
+static char *TCID = "mmap02";
+static int TST_TOTAL = 1;
 
 static char *addr;
 static char *dummy;

--- a/testcases/kernel/syscalls/mmap/mmap04.c
+++ b/testcases/kernel/syscalls/mmap/mmap04.c
@@ -51,8 +51,8 @@
 
 #define TEMPFILE	"mmapfile"
 
-char *TCID = "mmap04";
-int TST_TOTAL = 1;
+static char *TCID = "mmap04";
+static int TST_TOTAL = 1;
 
 static size_t page_sz;
 static char *addr;

--- a/testcases/kernel/syscalls/mmap/mmap06.c
+++ b/testcases/kernel/syscalls/mmap/mmap06.c
@@ -46,8 +46,8 @@
 
 #define TEMPFILE	"mmapfile"
 
-char *TCID = "mmap06";
-int TST_TOTAL = 1;
+static char *TCID = "mmap06";
+static int TST_TOTAL = 1;
 
 static size_t page_sz;
 static char *addr;

--- a/testcases/kernel/syscalls/mmap/mmap07.c
+++ b/testcases/kernel/syscalls/mmap/mmap07.c
@@ -47,8 +47,8 @@
 
 #define TEMPFILE	"mmapfile"
 
-char *TCID = "mmap07";
-int TST_TOTAL = 1;
+static char *TCID = "mmap07";
+static int TST_TOTAL = 1;
 
 static size_t page_sz;
 static char *addr;

--- a/testcases/kernel/syscalls/mmap/mmap08.c
+++ b/testcases/kernel/syscalls/mmap/mmap08.c
@@ -42,8 +42,8 @@
 
 #define TEMPFILE	"mmapfile"
 
-char *TCID = "mmap08";
-int TST_TOTAL = 1;
+static char *TCID = "mmap08";
+static int TST_TOTAL = 1;
 
 static size_t page_sz;
 static char *addr;

--- a/testcases/kernel/syscalls/mmap/mmap09.c
+++ b/testcases/kernel/syscalls/mmap/mmap09.c
@@ -42,8 +42,8 @@
 
 #define mapsize (1 << 14)
 
-char *TCID = "mmap09";
-int TST_TOTAL = 3;
+static char *TCID = "mmap09";
+static int TST_TOTAL = 3;
 
 static int fd;
 static char *maddr;

--- a/testcases/kernel/syscalls/mmap/mmap10.c
+++ b/testcases/kernel/syscalls/mmap/mmap10.c
@@ -67,17 +67,17 @@
 #define SIZE (5*1024*1024)
 #define PATH_KSM "/sys/kernel/mm/ksm/"
 
-char *TCID = "mmap10";
-int TST_TOTAL = 1;
+static char *TCID = "mmap10";
+static int TST_TOTAL = 1;
 
 static int fd, opt_anon, opt_ksm;
 static long ps;
 static char *x;
 
-void setup(void);
-void cleanup(void);
-void mmapzero(void);
-void help(void);
+static void setup(void);
+static void cleanup(void);
+static void mmapzero(void);
+static void help(void);
 
 static option_t options[] = {
 	{"a", &opt_anon, NULL},
@@ -118,7 +118,7 @@ int main(int argc, char *argv[])
 	tst_exit();
 }
 
-void mmapzero(void)
+static void mmapzero(void)
 {
 	int n;
 
@@ -184,11 +184,11 @@ void mmapzero(void)
 				 WEXITSTATUS(n));
 }
 
-void cleanup(void)
+static void cleanup(void)
 {
 }
 
-void setup(void)
+static void setup(void)
 {
 	tst_require_root();
 
@@ -199,7 +199,7 @@ void setup(void)
 		tst_brkm(TBROK | TERRNO, cleanup, "sysconf(_SC_PAGESIZE)");
 }
 
-void help(void)
+static void help(void)
 {
 	printf("  -a      Test anonymous pages\n");
 	printf("  -s      Add to KSM regions\n");

--- a/testcases/kernel/syscalls/mmap/mmap14.c
+++ b/testcases/kernel/syscalls/mmap/mmap14.c
@@ -34,8 +34,8 @@
 #define MMAPSIZE        (1UL<<20)
 #define LINELEN         256
 
-char *TCID = "mmap14";
-int TST_TOTAL = 1;
+static char *TCID = "mmap14";
+static int TST_TOTAL = 1;
 
 static char *addr;
 

--- a/testcases/kernel/syscalls/mmap/mmap15.c
+++ b/testcases/kernel/syscalls/mmap/mmap15.c
@@ -38,8 +38,8 @@
 #include "safe_macros.h"
 #include "lapi/abisize.h"
 
-char *TCID = "mmap15";
-int TST_TOTAL = 1;
+static char *TCID = "mmap15";
+static int TST_TOTAL = 1;
 
 #ifdef __ia64__
 # define HIGH_ADDR (void *)(0xa000000000000000UL)

--- a/testcases/kernel/syscalls/mmap/mmap16.c
+++ b/testcases/kernel/syscalls/mmap/mmap16.c
@@ -53,8 +53,8 @@ static int parentfd = -1;
 static int page_size;
 static int bug_reproduced;
 
-char *TCID = "mmap16";
-int TST_TOTAL = 1;
+static char *TCID = "mmap16";
+static int TST_TOTAL = 1;
 
 int main(int ac, char **av)
 {

--- a/testcases/kernel/syscalls/mount/mount01.c
+++ b/testcases/kernel/syscalls/mount/mount01.c
@@ -30,8 +30,8 @@
 static void setup(void);
 static void cleanup(void);
 
-char *TCID = "mount01";
-int TST_TOTAL = 1;
+static char *TCID = "mount01";
+static int TST_TOTAL = 1;
 
 #define DIR_MODE (S_IRWXU | S_IRUSR | S_IXUSR | S_IRGRP | S_IXGRP)
 #define MNTPOINT "mntpoint"

--- a/testcases/kernel/syscalls/mount/mount02.c
+++ b/testcases/kernel/syscalls/mount/mount02.c
@@ -49,7 +49,7 @@
 static void setup(void);
 static void cleanup(void);
 
-char *TCID = "mount02";
+static char *TCID = "mount02";
 
 #define DIR_MODE	(S_IRWXU | S_IRUSR | S_IXUSR | S_IRGRP | S_IXGRP)
 #define FILE_MODE	(S_IRWXU | S_IRWXG | S_IRWXO)
@@ -96,7 +96,7 @@ static struct test_case {
 	{&device, &file, &fs_type, 0, ENOTDIR, NULL, NULL},
 };
 
-int TST_TOTAL = ARRAY_SIZE(tc);
+static int TST_TOTAL = ARRAY_SIZE(tc);
 
 static void verify_mount(struct test_case *tc)
 {

--- a/testcases/kernel/syscalls/mount/mount04.c
+++ b/testcases/kernel/syscalls/mount/mount04.c
@@ -30,7 +30,7 @@
 static void setup(void);
 static void cleanup(void);
 
-char *TCID = "mount04";
+static char *TCID = "mount04";
 
 #define DIR_MODE	S_IRWXU | S_IRUSR | S_IXUSR | S_IRGRP | S_IXGRP
 
@@ -38,7 +38,7 @@ static char *mntpoint = "mntpoint";
 static const char *fs_type;
 static const char *device;
 
-int TST_TOTAL = 1;
+static int TST_TOTAL = 1;
 
 static void verify_mount(void)
 {

--- a/testcases/kernel/syscalls/move_mount/move_mount02.c
+++ b/testcases/kernel/syscalls/move_mount/move_mount02.c
@@ -9,7 +9,7 @@
 
 #define MNTPOINT	"mntpoint"
 
-int invalid_fd = -1, fsmfd;
+static int invalid_fd = -1, fsmfd;
 
 static struct tcase {
 	char *name;

--- a/testcases/kernel/syscalls/mprotect/mprotect01.c
+++ b/testcases/kernel/syscalls/mprotect/mprotect01.c
@@ -45,8 +45,8 @@
 #include "test.h"
 #include "safe_macros.h"
 
-char *TCID = "mprotect01";
-int TST_TOTAL = 3;
+static char *TCID = "mprotect01";
+static int TST_TOTAL = 3;
 
 struct test_case {
 	void *addr;
@@ -64,7 +64,7 @@ static void setup3(struct test_case *self);
 
 static int fd;
 
-struct test_case TC[] = {
+static struct test_case TC[] = {
 	/* Check for ENOMEM passing memory that cannot be accessed. */
 	{NULL, 0, PROT_READ, ENOMEM, setup1},
 

--- a/testcases/kernel/syscalls/mprotect/mprotect02.c
+++ b/testcases/kernel/syscalls/mprotect/mprotect02.c
@@ -47,8 +47,8 @@ static void sighandler(int sig);
 static void cleanup(void);
 static void setup(void);
 
-char *TCID = "mprotect02";
-int TST_TOTAL = 1;
+static char *TCID = "mprotect02";
+static int TST_TOTAL = 1;
 static int fd, status;
 static char file1[BUFSIZ];
 

--- a/testcases/kernel/syscalls/mprotect/mprotect03.c
+++ b/testcases/kernel/syscalls/mprotect/mprotect03.c
@@ -56,10 +56,10 @@
 static void cleanup(void);
 static void setup(void);
 
-char *TCID = "mprotect03";
-int TST_TOTAL = 1;
-int status;
-char file1[BUFSIZ];
+static char *TCID = "mprotect03";
+static int TST_TOTAL = 1;
+static int status;
+static char file1[BUFSIZ];
 
 int main(int ac, char **av)
 {

--- a/testcases/kernel/syscalls/mq_notify/mq_notify02.c
+++ b/testcases/kernel/syscalls/mq_notify/mq_notify02.c
@@ -26,7 +26,7 @@
 #include <mqueue.h>
 #include "test.h"
 
-char *TCID = "mq_notify02";
+static char *TCID = "mq_notify02";
 static void setup(void);
 static void cleanup(void);
 
@@ -38,7 +38,7 @@ static struct test_case_t {
 	{{.sigev_notify = SIGEV_SIGNAL, .sigev_signo = _NSIG+1}, EINVAL},
 };
 
-int TST_TOTAL = ARRAY_SIZE(test_cases);
+static int TST_TOTAL = ARRAY_SIZE(test_cases);
 static void mq_notify_verify(struct test_case_t *);
 
 int main(int argc, char **argv)

--- a/testcases/kernel/syscalls/mremap/mremap05.c
+++ b/testcases/kernel/syscalls/mremap/mremap05.c
@@ -43,7 +43,7 @@
 #include "test.h"
 #include "safe_macros.h"
 
-char *TCID = "mremap05";
+static char *TCID = "mremap05";
 
 #ifdef HAVE_MREMAP_FIXED
 

--- a/testcases/kernel/syscalls/munmap/munmap01.c
+++ b/testcases/kernel/syscalls/munmap/munmap01.c
@@ -79,16 +79,16 @@
 
 #define TEMPFILE	"mmapfile"
 
-char *TCID = "munmap01";
-int TST_TOTAL = 1;
+static char *TCID = "munmap01";
+static int TST_TOTAL = 1;
 
-char *addr;			/* addr of memory mapped region */
-int fildes;			/* file descriptor for tempfile */
-unsigned int map_len;		/* length of the region to be mapped */
+static char *addr;			/* addr of memory mapped region */
+static int fildes;			/* file descriptor for tempfile */
+static unsigned int map_len;		/* length of the region to be mapped */
 
-void setup();			/* Main setup function of test */
-void cleanup();			/* cleanup function for the test */
-void sig_handler();		/* signal catching function */
+static void setup();			/* Main setup function of test */
+static void cleanup();			/* cleanup function for the test */
+static void sig_handler();		/* signal catching function */
 
 int main(int ac, char **av)
 {
@@ -148,7 +148,7 @@ int main(int ac, char **av)
  * write one byte data into it, map the open file for the specified
  * map length.
  */
-void setup(void)
+static void setup(void)
 {
 	size_t page_sz;
 
@@ -220,7 +220,7 @@ void setup(void)
  *   this function is invoked when SIGSEGV generated and it calls test
  *   cleanup function and exit the program.
  */
-void sig_handler(void)
+static void sig_handler(void)
 {
 	tst_resm(TPASS, "Functionality of munmap() successful");
 
@@ -236,7 +236,7 @@ void sig_handler(void)
  *  	       Close the temporary file.
  *  	       Remove the temporary directory.
  */
-void cleanup(void)
+static void cleanup(void)
 {
 
 	/* Close the temporary file */

--- a/testcases/kernel/syscalls/munmap/munmap02.c
+++ b/testcases/kernel/syscalls/munmap/munmap02.c
@@ -80,17 +80,17 @@
 
 #define TEMPFILE	"mmapfile"
 
-char *TCID = "munmap02";
-int TST_TOTAL = 1;
+static char *TCID = "munmap02";
+static int TST_TOTAL = 1;
 
 static size_t page_sz;
-char *addr;			/* addr of memory mapped region */
-int fildes;			/* file descriptor for tempfile */
-unsigned int map_len;		/* length of the region to be mapped */
+static char *addr;			/* addr of memory mapped region */
+static int fildes;			/* file descriptor for tempfile */
+static unsigned int map_len;		/* length of the region to be mapped */
 
-void setup();			/* Main setup function of test */
-void cleanup();			/* cleanup function for the test */
-void sig_handler();		/* signal catching function */
+static void setup();			/* Main setup function of test */
+static void cleanup();			/* cleanup function for the test */
+static void sig_handler();		/* signal catching function */
 
 #ifndef UCLINUX
 
@@ -153,7 +153,7 @@ int main(void)
  * write one byte data into it, map the open file for the specified
  * map length.
  */
-void setup(void)
+static void setup(void)
 {
 
 	tst_sig(NOFORK, DEF_HANDLER, cleanup);
@@ -233,7 +233,7 @@ void setup(void)
  *   this function is invoked when SIGSEGV generated and it calls test
  *   cleanup function and exit the program.
  */
-void sig_handler(void)
+static void sig_handler(void)
 {
 	tst_resm(TPASS, "Functionality of munmap() successful");
 
@@ -250,7 +250,7 @@ void sig_handler(void)
  *  Close the temporary file.
  *  Remove the temporary directory.
  */
-void cleanup(void)
+static void cleanup(void)
 {
 
 	/*

--- a/testcases/kernel/syscalls/munmap/munmap03.c
+++ b/testcases/kernel/syscalls/munmap/munmap03.c
@@ -43,7 +43,7 @@
 #include "test.h"
 #include "safe_macros.h"
 
-char *TCID = "munmap03";
+static char *TCID = "munmap03";
 
 static size_t page_sz;
 static char *global_addr;
@@ -56,7 +56,7 @@ static void test_einval1(void);
 static void test_einval2(void);
 static void test_einval3(void);
 static void (*testfunc[])(void) = { test_einval1, test_einval2, test_einval3 };
-int TST_TOTAL = ARRAY_SIZE(testfunc);
+static int TST_TOTAL = ARRAY_SIZE(testfunc);
 
 int main(int ac, char **av)
 {

--- a/testcases/kernel/syscalls/nanosleep/nanosleep01.c
+++ b/testcases/kernel/syscalls/nanosleep/nanosleep01.c
@@ -14,7 +14,7 @@
 #include <errno.h>
 #include "tst_timer_test.h"
 
-int sample_fn(int clk_id, long long usec)
+static int sample_fn(int clk_id, long long usec)
 {
 	struct timespec t = tst_timespec_from_us(usec);
 

--- a/testcases/kernel/syscalls/nftw/nftw.c
+++ b/testcases/kernel/syscalls/nftw/nftw.c
@@ -28,42 +28,42 @@
 #include <pwd.h>
 #include "nftw.h"
 
-void setup(void);
-void blenter(void);
-void blexit(void);
-void anyfail(void);
+static void setup(void);
+static void blenter(void);
+static void blexit(void);
+static void anyfail(void);
 
-char progname[] = "nftw.c";
+static char progname[] = "nftw.c";
 
 /** LTP Port **/
 #define FAILED 0
 #define PASSED 1
 
-int local_flag = PASSED;
-int block_number;
+static int local_flag = PASSED;
+static int block_number;
 
-FILE *temp;
-char *TCID = "nftw01";
-int TST_TOTAL = 10;
+static FILE *temp;
+static char *TCID = "nftw01";
+static int TST_TOTAL = 10;
 
-struct passwd *ltpuser;		/* password struct for ltpuser */
+static struct passwd *ltpuser;		/* password struct for ltpuser */
 /**************/
 
 /* Used for error return for some library routines */
-int s2;
+static int s2;
 
 /* error messages formatted here. */
-char ebuf[ERR_BUF_SIZ];
+static char ebuf[ERR_BUF_SIZ];
 
 /*
  * Local data declarations.
  */
-char *dirlist[NDIRLISTENTS];
+static char *dirlist[NDIRLISTENTS];
 
-int visit;
-int next_fd[4];
+static int visit;
+static int next_fd[4];
 
-pathdata pathdat[] = {
+static pathdata pathdat[] = {
 	{
 	 "./tmp/data",
 	 S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH,
@@ -212,7 +212,7 @@ pathdata pathdat[] = {
 										"./loop"}
 };
 
-char *goodlist[] = {
+static char *goodlist[] = {
 	"/dirh",
 	"/dirh/dir_left.1",
 	"/dirh/dir_right.1",
@@ -222,7 +222,7 @@ char *goodlist[] = {
 	"/dirh/dir_right.1/dir_right.2/right.3"
 };
 
-struct list badlist[] = {
+static struct list badlist[] = {
 	{"/dirg", FTW_D},
 	{"/dirg/dir_left.1", FTW_D},
 	/* not FTW_NS in following since stat can't fail if file exists */
@@ -234,7 +234,7 @@ struct list badlist[] = {
 	{"/dirg/dir_left.1/dir_left.2/left.3", FTW_F},
 };
 
-struct list mnem[] = {
+static struct list mnem[] = {
 	{"FTW_F", FTW_F},
 	{"FTW_D", FTW_D},
 	{"FTW_DNR", FTW_DNR},
@@ -247,7 +247,7 @@ struct list mnem[] = {
 #endif
 };
 
-int npathdats, ngoods, nbads, nmnem;
+static int npathdats, ngoods, nbads, nmnem;
 
 /*--------------------------------------------------------------*/
 int main(void)
@@ -671,7 +671,7 @@ int main(void)
  *
  * Do set up - here its a dummy function
  */
-void setup(void)
+static void setup(void)
 {
 	/* Direct debug output to stderr */
 	temp = stderr;
@@ -693,7 +693,7 @@ void setup(void)
  *
  * Description: Print message on entering a new block
  */
-void blenter(void)
+static void blenter(void)
 {
 	local_flag = PASSED;
 	return;
@@ -706,7 +706,7 @@ void blenter(void)
  *              of a test. It will report the status if the test ie fail or
  *              pass.
  */
-void blexit(void)
+static void blexit(void)
 {
 	(local_flag == PASSED) ? tst_resm(TPASS, "Test block %d", block_number)
 	    : tst_resm(TFAIL, "Test block %d", block_number);
@@ -720,7 +720,7 @@ void blexit(void)
  *
  * Description: Exit a test.
  */
-void anyfail(void)
+static void anyfail(void)
 {
 	(local_flag == FAILED) ? tst_resm(TFAIL, "Test failed")
 	    : tst_resm(TPASS, "Test passed");

--- a/testcases/kernel/syscalls/nftw/nftw64.c
+++ b/testcases/kernel/syscalls/nftw/nftw64.c
@@ -28,25 +28,25 @@
 #include <pwd.h>
 #include "nftw64.h"
 
-void setup(void);
-void blenter(void);
-void blexit(void);
-void anyfail(void);
+static void setup(void);
+static void blenter(void);
+static void blexit(void);
+static void anyfail(void);
 
-char progname[] = "nftw64.c";
+static char progname[] = "nftw64.c";
 
 /** LTP Port **/
 #define FAILED 0
 #define PASSED 1
 
-int local_flag = PASSED;
-int block_number;
+static int local_flag = PASSED;
+static int block_number;
 
 FILE *temp;
-char *TCID = "nftw6401";
-int TST_TOTAL = 10;
+static char *TCID = "nftw6401";
+static int TST_TOTAL = 10;
 
-struct passwd *ltpuser;		/* password struct for ltpuser */
+static struct passwd *ltpuser;		/* password struct for ltpuser */
 /**************/
 
 /* Used for error return for some library routines */
@@ -698,7 +698,7 @@ int main(void)
  *
  * Do set up - here its a dummy function
  */
-void setup(void)
+static void setup(void)
 {
 	/* Direct debug output to stderr */
 	temp = stderr;
@@ -720,7 +720,7 @@ void setup(void)
  *
  * Description: Print message on entering a new block
  */
-void blenter(void)
+static void blenter(void)
 {
 	local_flag = PASSED;
 	return;
@@ -733,7 +733,7 @@ void blenter(void)
  *              of a test. It will report the status if the test ie fail or
  *              pass.
  */
-void blexit(void)
+static void blexit(void)
 {
 	(local_flag == PASSED) ? tst_resm(TPASS, "Test block %d", block_number)
 	    : tst_resm(TFAIL, "Test block %d", block_number);
@@ -747,7 +747,7 @@ void blexit(void)
  *
  * Description: Exit a test.
  */
-void anyfail(void)
+static void anyfail(void)
 {
 	(local_flag == FAILED) ? tst_resm(TFAIL, "Test failed")
 	    : tst_resm(TPASS, "Test passed");

--- a/testcases/kernel/syscalls/open/open02.c
+++ b/testcases/kernel/syscalls/open/open02.c
@@ -33,7 +33,7 @@ static struct tcase {
 	{TEST_FILE2, O_RDONLY | O_NOATIME, EPERM},
 };
 
-void setup(void)
+static void setup(void)
 {
 	struct passwd *ltpuser;
 
@@ -66,7 +66,7 @@ static void verify_open(unsigned int n)
 	tst_res(TPASS | TTERRNO, "open() failed as expected");
 }
 
-void cleanup(void)
+static void cleanup(void)
 {
 	SAFE_SETEUID(0);
 }

--- a/testcases/kernel/syscalls/open/open03.c
+++ b/testcases/kernel/syscalls/open/open03.c
@@ -36,8 +36,8 @@
 static void setup(void);
 static void cleanup(void);
 
-char *TCID = "open03";
-int TST_TOTAL = 1;
+static char *TCID = "open03";
+static int TST_TOTAL = 1;
 
 static char fname[255];
 static int fd;

--- a/testcases/kernel/syscalls/open/open04.c
+++ b/testcases/kernel/syscalls/open/open04.c
@@ -35,8 +35,8 @@
 #include <unistd.h>
 #include "test.h"
 
-char *TCID = "open04";
-int TST_TOTAL = 1;
+static char *TCID = "open04";
+static int TST_TOTAL = 1;
 
 static int fd, ifile, mypid, first;
 static int nfile;

--- a/testcases/kernel/syscalls/open/open05.c
+++ b/testcases/kernel/syscalls/open/open05.c
@@ -37,8 +37,8 @@
 #include "test.h"
 #include "safe_macros.h"
 
-char *TCID = "open05";
-int TST_TOTAL = 1;
+static char *TCID = "open05";
+static int TST_TOTAL = 1;
 
 static char fname[20];
 static int fd;

--- a/testcases/kernel/syscalls/open/open06.c
+++ b/testcases/kernel/syscalls/open/open06.c
@@ -33,8 +33,8 @@
 #include <unistd.h>
 #include "test.h"
 
-char *TCID = "open06";
-int TST_TOTAL = 1;
+static char *TCID = "open06";
+static int TST_TOTAL = 1;
 
 static void setup(void);
 static void cleanup(void);

--- a/testcases/kernel/syscalls/open/open09.c
+++ b/testcases/kernel/syscalls/open/open09.c
@@ -29,8 +29,8 @@
 #include <fcntl.h>
 #include "test.h"
 
-char *TCID = "open09";
-int TST_TOTAL = 2;
+static char *TCID = "open09";
+static int TST_TOTAL = 2;
 
 #define PASSED 1
 #define FAILED 0

--- a/testcases/kernel/syscalls/open/open10.c
+++ b/testcases/kernel/syscalls/open/open10.c
@@ -43,8 +43,8 @@
 #include <pwd.h>
 #include "test.h"
 
-char *TCID = "open10";
-int TST_TOTAL = 1;
+static char *TCID = "open10";
+static int TST_TOTAL = 1;
 static int local_flag;
 
 #define PASSED 1

--- a/testcases/kernel/syscalls/open/open13.c
+++ b/testcases/kernel/syscalls/open/open13.c
@@ -65,8 +65,8 @@ static void (*test_func[])(void) = {
 #endif
 };
 
-char *TCID = "open13";
-int TST_TOTAL = ARRAY_SIZE(test_func);
+static char *TCID = "open13";
+static int TST_TOTAL = ARRAY_SIZE(test_func);
 
 int main(int ac, char **av)
 {

--- a/testcases/kernel/syscalls/open/open14.c
+++ b/testcases/kernel/syscalls/open/open14.c
@@ -29,8 +29,8 @@
 #include "safe_macros.h"
 #include "lapi/fcntl.h"
 
-char *TCID = "open14";
-int TST_TOTAL = 3;
+static char *TCID = "open14";
+static int TST_TOTAL = 3;
 static ssize_t size;
 static char buf[1024];
 static const ssize_t blocks_num = 4;
@@ -69,7 +69,7 @@ static void write_file(int fd)
 		SAFE_WRITE(cleanup, 1, fd, buf, size);
 }
 
-void test01(void)
+static void test01(void)
 {
 	int fd;
 	char path[PATH_MAX], tmp[PATH_MAX];

--- a/testcases/kernel/syscalls/openat/openat01.c
+++ b/testcases/kernel/syscalls/openat/openat01.c
@@ -42,7 +42,7 @@
 static void setup(void);
 static void cleanup(void);
 
-char *TCID = "openat01";
+static char *TCID = "openat01";
 
 static int dir_fd, fd;
 static int fd_invalid = 100;
@@ -66,7 +66,7 @@ static struct test_case {
 	{&fd_atcwd, TEST_DIR TEST_FILE, 0, 0}
 };
 
-int TST_TOTAL = ARRAY_SIZE(test_cases);
+static int TST_TOTAL = ARRAY_SIZE(test_cases);
 
 static void verify_openat(struct test_case *test)
 {

--- a/testcases/kernel/syscalls/openat/openat02_child.c
+++ b/testcases/kernel/syscalls/openat/openat02_child.c
@@ -22,7 +22,7 @@
 
 #define STR "abc"
 
-char *TCID = "openat02_child";
+static char *TCID = "openat02_child";
 
 int main(int argc, char **argv)
 {

--- a/testcases/kernel/syscalls/openat/openat03.c
+++ b/testcases/kernel/syscalls/openat/openat03.c
@@ -30,8 +30,8 @@
 #include "lapi/fcntl.h"
 #include "openat.h"
 
-char *TCID = "openat03";
-int TST_TOTAL = 3;
+static char *TCID = "openat03";
+static int TST_TOTAL = 3;
 static ssize_t size;
 static char buf[1024];
 static const ssize_t blocks_num = 4;
@@ -80,7 +80,7 @@ static void write_file(int fd)
 		SAFE_WRITE(cleanup, 1, fd, buf, size);
 }
 
-void test01(void)
+static void test01(void)
 {
 	int fd;
 	char path[PATH_MAX], tmp[PATH_MAX];

--- a/testcases/kernel/syscalls/pathconf/pathconf01.c
+++ b/testcases/kernel/syscalls/pathconf/pathconf01.c
@@ -115,11 +115,11 @@
 #include <signal.h>
 #include "test.h"
 
-void setup();
-void cleanup();
-void help();
+static void setup();
+static void cleanup();
+static void help();
 
-struct pathconf_args {
+static struct pathconf_args {
 	char *define_tag;
 	int value;
 } args[] = {
@@ -133,14 +133,14 @@ struct pathconf_args {
 	NULL, 0}
 };
 
-char *TCID = "pathconf01";
-int TST_TOTAL = ARRAY_SIZE(args);
+static char *TCID = "pathconf01";
+static int TST_TOTAL = ARRAY_SIZE(args);
 
 int i;
 
 
 int lflag;
-char *path;
+static char *path;
 
 option_t options[] = {
 	{"l:", &lflag, &path},	/* -l <path to test> */
@@ -208,7 +208,7 @@ int main(int ac, char **av)
 /***************************************************************
  * setup() - performs all ONE TIME setup for this test.
  ***************************************************************/
-void setup(void)
+static void setup(void)
 {
 
 	tst_sig(NOFORK, DEF_HANDLER, cleanup);
@@ -220,7 +220,7 @@ void setup(void)
  * cleanup() - performs all ONE TIME cleanup for this test at
  *		completion or premature exit.
  ***************************************************************/
-void cleanup(void)
+static void cleanup(void)
 {
 	if (!lflag) {
 		tst_rmdir();
@@ -231,7 +231,7 @@ void cleanup(void)
 /***************************************************************
  * help
  ***************************************************************/
-void help(void)
+static void help(void)
 {
 	printf("  -l path a path to test with pathconf(2) (def: /tmp)\n");
 }

--- a/testcases/kernel/syscalls/pause/pause02.c
+++ b/testcases/kernel/syscalls/pause/pause02.c
@@ -30,8 +30,8 @@
 
 #include "test.h"
 
-char *TCID = "pause02";
-int TST_TOTAL = 1;
+static char *TCID = "pause02";
+static int TST_TOTAL = 1;
 static pid_t cpid;
 
 static void do_child(void);

--- a/testcases/kernel/syscalls/pause/pause03.c
+++ b/testcases/kernel/syscalls/pause/pause03.c
@@ -31,8 +31,8 @@
 
 static pid_t cpid;
 
-char *TCID = "pause03";
-int TST_TOTAL = 1;
+static char *TCID = "pause03";
+static int TST_TOTAL = 1;
 
 static void do_child(void);
 static void setup(void);

--- a/testcases/kernel/syscalls/perf_event_open/perf_event_open01.c
+++ b/testcases/kernel/syscalls/perf_event_open/perf_event_open01.c
@@ -46,7 +46,7 @@
 #include "lapi/syscalls.h"
 #include "safe_macros.h"
 
-char *TCID = "perf_event_open01";
+static char *TCID = "perf_event_open01";
 
 #if HAVE_PERF_EVENT_ATTR
 static void setup(void);
@@ -73,7 +73,7 @@ static struct test_case_t {
 	  PERF_COUNT_SW_TASK_CLOCK },
 };
 
-int TST_TOTAL = ARRAY_SIZE(event_types);
+static int TST_TOTAL = ARRAY_SIZE(event_types);
 
 static void verify(struct test_case_t *tc);
 static struct perf_event_attr pe;

--- a/testcases/kernel/syscalls/pipe/pipe04.c
+++ b/testcases/kernel/syscalls/pipe/pipe04.c
@@ -51,18 +51,18 @@
 #include "test.h"
 #include "safe_macros.h"
 
-char *TCID = "pipe04";
-int TST_TOTAL = 1;
+static char *TCID = "pipe04";
+static int TST_TOTAL = 1;
 
-int fildes[2];			/* fds for pipe read and write */
+static int fildes[2];			/* fds for pipe read and write */
 
-void setup(void);
-void cleanup(void);
-void c1func(void);
-void c2func(void);
-void alarmfunc(int);
+static void setup(void);
+static void cleanup(void);
+static void c1func(void);
+static void c2func(void);
+static void alarmfunc(int);
 
-ssize_t do_read(int fd, void *buf, size_t count)
+static ssize_t do_read(int fd, void *buf, size_t count)
 {
 	ssize_t n;
 
@@ -201,7 +201,7 @@ int main(int ac, char **av)
 /*
  * setup() - performs all ONE TIME setup for this test.
  */
-void setup(void)
+static void setup(void)
 {
 
 	tst_sig(FORK, DEF_HANDLER, cleanup);
@@ -213,11 +213,11 @@ void setup(void)
  * cleanup() - performs all ONE TIME cleanup for this test at
  *	       completion or premature exit.
  */
-void cleanup(void)
+static void cleanup(void)
 {
 }
 
-void c1func(void)
+static void c1func(void)
 {
 	if (close(fildes[0]) == -1)
 		tst_resm(TWARN, "Could not close fildes[0] - errno %d", errno);
@@ -226,7 +226,7 @@ void c1func(void)
 			tst_resm(TBROK | TERRNO, "[child 1] pipe write failed");
 }
 
-void c2func(void)
+static void c2func(void)
 {
 	if (close(fildes[0]) == -1)
 		tst_resm(TWARN, "Could not close fildes[0] - errno %d", errno);
@@ -235,7 +235,7 @@ void c2func(void)
 			tst_resm(TBROK | TERRNO, "[child 2] pipe write failed");
 }
 
-void alarmfunc(int sig LTP_ATTRIBUTE_UNUSED)
+static void alarmfunc(int sig LTP_ATTRIBUTE_UNUSED)
 {
 	/* for some reason tst_brkm doesn't seem to work in a signal handler */
 	tst_brkm(TFAIL, cleanup, "one or more children did't die in 60 second "

--- a/testcases/kernel/syscalls/pipe/pipe07.c
+++ b/testcases/kernel/syscalls/pipe/pipe07.c
@@ -40,8 +40,8 @@
 #include "test.h"
 #include "safe_macros.h"
 
-char *TCID = "pipe07";
-int TST_TOTAL = 1;
+static char *TCID = "pipe07";
+static int TST_TOTAL = 1;
 
 /* used to record file descriptors open at the test start */
 static int rec_fds[128];

--- a/testcases/kernel/syscalls/pipe/pipe08.c
+++ b/testcases/kernel/syscalls/pipe/pipe08.c
@@ -53,12 +53,12 @@
 #include <string.h>
 #include "test.h"
 
-char *TCID = "pipe08";
-int TST_TOTAL = 1;
+static char *TCID = "pipe08";
+static int TST_TOTAL = 1;
 
-void setup(void);
-void cleanup(void);
-void sighandler(int);
+static void setup(void);
+static void cleanup(void);
+static void sighandler(int);
 
 int main(int ac, char **av)
 {
@@ -109,7 +109,7 @@ int main(int ac, char **av)
 /*
  * sighandler - catch signals and look for SIGPIPE
  */
-void sighandler(int sig)
+static void sighandler(int sig)
 {
 	if (sig != SIGPIPE)
 		tst_resm(TFAIL, "expected SIGPIPE, got %d", sig);
@@ -120,7 +120,7 @@ void sighandler(int sig)
 /*
  * setup() - performs all ONE TIME setup for this test.
  */
-void setup(void)
+static void setup(void)
 {
 
 	tst_sig(NOFORK, sighandler, cleanup);
@@ -132,6 +132,6 @@ void setup(void)
  * cleanup() - performs all ONE TIME cleanup for this test at
  *	       completion or premature exit.
  */
-void cleanup(void)
+static void cleanup(void)
 {
 }

--- a/testcases/kernel/syscalls/pipe/pipe09.c
+++ b/testcases/kernel/syscalls/pipe/pipe09.c
@@ -55,13 +55,13 @@
 
 #define	PIPEWRTCNT	100	/* must be an even number */
 
-char *TCID = "pipe09";
-int TST_TOTAL = 1;
+static char *TCID = "pipe09";
+static int TST_TOTAL = 1;
 
-void setup(void);
-void cleanup(void);
+static void setup(void);
+static void cleanup(void);
 
-ssize_t do_read(int fd, void *buf, size_t count)
+static ssize_t do_read(int fd, void *buf, size_t count)
 {
 	ssize_t n;
 
@@ -196,7 +196,7 @@ int main(int ac, char **av)
 /*
  * setup() - performs all ONE TIME setup for this test.
  */
-void setup(void)
+static void setup(void)
 {
 
 	tst_sig(FORK, DEF_HANDLER, cleanup);
@@ -208,6 +208,6 @@ void setup(void)
  * cleanup() - performs all ONE TIME cleanup for this test at
  *	       completion or premature exit.
  */
-void cleanup(void)
+static void cleanup(void)
 {
 }

--- a/testcases/kernel/syscalls/pipe/pipe10.c
+++ b/testcases/kernel/syscalls/pipe/pipe10.c
@@ -49,13 +49,13 @@
 #include <string.h>
 #include "test.h"
 
-char *TCID = "pipe10";
-int TST_TOTAL = 1;
+static char *TCID = "pipe10";
+static int TST_TOTAL = 1;
 
-void setup(void);
-void cleanup(void);
+static void setup(void);
+static void cleanup(void);
 
-ssize_t do_read(int fd, void *buf, size_t count)
+static ssize_t do_read(int fd, void *buf, size_t count)
 {
 	ssize_t n;
 
@@ -147,7 +147,7 @@ int main(int ac, char **av)
 /*
  * setup() - performs all ONE TIME setup for this test.
  */
-void setup(void)
+static void setup(void)
 {
 
 	tst_sig(FORK, DEF_HANDLER, cleanup);
@@ -159,6 +159,6 @@ void setup(void)
  * cleanup() - performs all ONE TIME cleanup for this test at
  *	       completion or premature exit.
  */
-void cleanup(void)
+static void cleanup(void)
 {
 }

--- a/testcases/kernel/syscalls/poll/poll02.c
+++ b/testcases/kernel/syscalls/poll/poll02.c
@@ -15,7 +15,7 @@
 
 static int fds[2];
 
-int sample_fn(int clk_id, long long usec)
+static int sample_fn(int clk_id, long long usec)
 {
 	unsigned int sleep_ms = usec / 1000;
 

--- a/testcases/kernel/syscalls/prctl/prctl09.c
+++ b/testcases/kernel/syscalls/prctl/prctl09.c
@@ -14,7 +14,7 @@
 #include "lapi/prctl.h"
 #include "tst_timer_test.h"
 
-int sample_fn(int clk_id, long long usec)
+static int sample_fn(int clk_id, long long usec)
 {
 	struct timespec t = tst_timespec_from_us(usec);
 

--- a/testcases/kernel/syscalls/pread/pread01.c
+++ b/testcases/kernel/syscalls/pread/pread01.c
@@ -85,18 +85,18 @@
 #define K4              (K1 * 4)
 #define NBUFS           4
 
-char *TCID = "pread01";
-int TST_TOTAL = 1;
+static char *TCID = "pread01";
+static int TST_TOTAL = 1;
 
-int fildes;			/* file descriptor for tempfile */
-char *write_buf[NBUFS];		/* buffer to hold data to be written */
-char *read_buf[NBUFS];		/* buffer to hold data read from file */
+static int fildes;			/* file descriptor for tempfile */
+static char *write_buf[NBUFS];		/* buffer to hold data to be written */
+static char *read_buf[NBUFS];		/* buffer to hold data read from file */
 
-void setup();			/* Main setup function of test */
-void cleanup();			/* cleanup function for the test */
-void l_seek(int, off_t, int, off_t);	/* function to call lseek() */
-void init_buffers();		/* function to initialize/allocate buffers */
-void compare_bufers();		/* function to compare o/p of pread/pwrite */
+static void setup();			/* Main setup function of test */
+static void cleanup();			/* cleanup function for the test */
+static void l_seek(int, off_t, int, off_t);	/* function to call lseek() */
+static void init_buffers();		/* function to initialize/allocate buffers */
+static void compare_bufers();		/* function to compare o/p of pread/pwrite */
 
 int main(int ac, char **av)
 {
@@ -187,7 +187,7 @@ int main(int ac, char **av)
  *  Create a temporary directory and a file under it and
  *  write know data at different offset positions.
  */
-void setup(void)
+static void setup(void)
 {
 	int nwrite = 0;		/* no. of bytes written by pwrite() */
 
@@ -259,7 +259,7 @@ void setup(void)
  *    write_buf[0] has 0's, write_buf[1] has 1's, write_buf[2] has 2's
  *    write_buf[3] has 3's.
  */
-void init_buffers(void)
+static void init_buffers(void)
 {
 	int count;		/* counter variable for loop */
 
@@ -282,7 +282,7 @@ void init_buffers(void)
  *  "checkoff" is the offset at which we believe we should be at.
  *  Used to validate pread/pwrite don't move the offset.
  */
-void l_seek(int fdesc, off_t offset, int whence, off_t checkoff)
+static void l_seek(int fdesc, off_t offset, int whence, off_t checkoff)
 {
 	off_t offloc;		/* offset ret. from lseek() */
 
@@ -304,7 +304,7 @@ void l_seek(int fdesc, off_t offset, int whence, off_t checkoff)
  *  This function does memcmp of read/write buffer and display message
  *  about the functionality of pread().
  */
-void compare_bufers(void)
+static void compare_bufers(void)
 {
 	int count;		/* index for the loop */
 	int err_flg = 0;	/* flag to indicate error */
@@ -330,7 +330,7 @@ void compare_bufers(void)
  *             Close the temporary file.
  *             Remove the temporary directory created.
  */
-void cleanup(void)
+static void cleanup(void)
 {
 	int count;
 

--- a/testcases/kernel/syscalls/pread/pread02.c
+++ b/testcases/kernel/syscalls/pread/pread02.c
@@ -78,22 +78,22 @@
 #define K1              1024
 #define NBUFS           4
 
-char *TCID = "pread02";
-int TST_TOTAL = 2;
+static char *TCID = "pread02";
+static int TST_TOTAL = 2;
 
-char *write_buf[NBUFS];		/* buffer to hold data to be written */
-char *read_buf[NBUFS];		/* buffer to hold data read from file */
-int pfd[2];			/* pair of file descriptors */
-int fd1;
+static char *write_buf[NBUFS];		/* buffer to hold data to be written */
+static char *read_buf[NBUFS];		/* buffer to hold data read from file */
+static int pfd[2];			/* pair of file descriptors */
+static int fd1;
 
-void setup();			/* Main setup function of test */
-void cleanup();			/* cleanup function for the test */
-int setup1();			/* setup function for test #1 */
-int setup2();			/* setup function for test #2 */
-int no_setup();
-void init_buffers();		/* function to initialize/allocate buffers */
+static void setup();			/* Main setup function of test */
+static void cleanup();			/* cleanup function for the test */
+static int setup1();			/* setup function for test #1 */
+static int setup2();			/* setup function for test #2 */
+static int no_setup();
+static void init_buffers();		/* function to initialize/allocate buffers */
 
-struct test_case_t {		/* test case struct. to hold ref. test cond's */
+static struct test_case_t {		/* test case struct. to hold ref. test cond's */
 	int fd;
 	size_t nb;
 	off_t offst;
@@ -176,7 +176,7 @@ int main(int ac, char **av)
  *           Initialize/allocate write buffer.
  *           Call individual setup function.
  */
-void setup(void)
+static void setup(void)
 {
 	int i;
 
@@ -196,7 +196,7 @@ void setup(void)
 /*
  * no_setup() - This function simply returns.
  */
-int no_setup(void)
+static int no_setup(void)
 {
 	return 0;
 }
@@ -209,7 +209,7 @@ int no_setup(void)
  *  Write some known data to the write end of the pipe.
  *  return 0.
  */
-int setup1(void)
+static int setup1(void)
 {
 	/* Create a pair of unnamed pipe */
 	SAFE_PIPE(cleanup, pfd);
@@ -230,7 +230,7 @@ int setup1(void)
  *  Create a temporary directory and a file under it.
  *  return 0.
  */
-int setup2(void)
+static int setup2(void)
 {
 
 	tst_tmpdir();
@@ -252,7 +252,7 @@ int setup2(void)
  *    write_buf[0] has 0's, write_buf[1] has 1's, write_buf[2] has 2's
  *    write_buf[3] has 3's.
  */
-void init_buffers(void)
+static void init_buffers(void)
 {
 	int count;		/* counter variable for loop */
 
@@ -277,7 +277,7 @@ void init_buffers(void)
  *  Close the temporary file.
  *  Remove the temporary directory created.
  */
-void cleanup(void)
+static void cleanup(void)
 {
 	int count;
 

--- a/testcases/kernel/syscalls/pread/pread03.c
+++ b/testcases/kernel/syscalls/pread/pread03.c
@@ -61,7 +61,7 @@
  *             -t   : Turn on syscall timing.
  *
  * HISTORY
- *	04/2002 Ported by André Merlier
+ *	04/2002 Ported by Andrï¿½ Merlier
  *
  * RESTRICTIONS:
  *  None.
@@ -84,15 +84,15 @@
 #define K1              2048
 #define NBUFS           1
 
-char *TCID = "pread03";
-int TST_TOTAL = 1;
+static char *TCID = "pread03";
+static int TST_TOTAL = 1;
 
-char *read_buf[NBUFS];		/* buffer to hold data read from file */
-int fd1;
+static char *read_buf[NBUFS];		/* buffer to hold data read from file */
+static int fd1;
 
-void setup();			/* Main setup function of test */
-void cleanup();			/* cleanup function for the test */
-void init_buffers();		/* function to initialize/allocate buffers */
+static void setup();			/* Main setup function of test */
+static void cleanup();			/* cleanup function for the test */
+static void init_buffers();		/* function to initialize/allocate buffers */
 
 int main(int ac, char **av)
 {
@@ -146,7 +146,7 @@ int main(int ac, char **av)
  * setup() - performs all ONE TIME setup for this test.
  *           create temporary directory and open it
  */
-void setup(void)
+static void setup(void)
 {
 	tst_sig(FORK, DEF_HANDLER, cleanup);
 
@@ -178,7 +178,7 @@ void setup(void)
  *
  *  Allocate read buffer.
  */
-void init_buffers(void)
+static void init_buffers(void)
 {
 	int count;		/* counter variable for loop */
 
@@ -199,7 +199,7 @@ void init_buffers(void)
  *
  *  Close/Remove the temporary directory created.
  */
-void cleanup(void)
+static void cleanup(void)
 {
 	int count;
 

--- a/testcases/kernel/syscalls/preadv/preadv01.c
+++ b/testcases/kernel/syscalls/preadv/preadv01.c
@@ -81,7 +81,7 @@ void verify_preadv(unsigned int n)
 		 "with content '%c' expectedly", tc->size, tc->content);
 }
 
-void setup(void)
+static void setup(void)
 {
 	char buf[CHUNK];
 
@@ -94,7 +94,7 @@ void setup(void)
 	SAFE_WRITE(1, fd, buf, sizeof(buf));
 }
 
-void cleanup(void)
+static void cleanup(void)
 {
 	if (fd > 0)
 		SAFE_CLOSE(fd);

--- a/testcases/kernel/syscalls/profil/profil01.c
+++ b/testcases/kernel/syscalls/profil/profil01.c
@@ -30,7 +30,7 @@
 #include "lapi/abisize.h"
 #include "config.h"
 
-char *TCID = "profil01";
+static char *TCID = "profil01";
 
 #if HAVE_PROFIL
 
@@ -42,7 +42,7 @@ char *TCID = "profil01";
  * just in case compiler put call to get_pc() below "data shuffling" code */
 #define PROFIL_BUFLEN (32*1024)
 
-int TST_TOTAL = 1;
+static int TST_TOTAL = 1;
 
 static volatile sig_atomic_t profil_done;
 

--- a/testcases/kernel/syscalls/pselect/pselect01.c
+++ b/testcases/kernel/syscalls/pselect/pselect01.c
@@ -9,7 +9,7 @@
 
 #include "tst_timer_test.h"
 
-int sample_fn(int clk_id, long long usec)
+static int sample_fn(int clk_id, long long usec)
 {
 	fd_set readfds;
 	struct timespec tv = tst_timespec_from_us(usec);

--- a/testcases/kernel/syscalls/pselect/pselect02.c
+++ b/testcases/kernel/syscalls/pselect/pselect02.c
@@ -48,7 +48,7 @@ static struct test_case_t {
 	{128, NULL, &time_buf, EINVAL},
 };
 
-int TST_TOTAL = ARRAY_SIZE(test_cases);
+static int TST_TOTAL = ARRAY_SIZE(test_cases);
 
 static void setup(void);
 static void cleanup(void);

--- a/testcases/kernel/syscalls/pwrite/pwrite01.c
+++ b/testcases/kernel/syscalls/pwrite/pwrite01.c
@@ -88,16 +88,16 @@
 #define K4              (K1 * 4)
 #define NBUFS           4
 
-char *TCID = "pwrite01";
-int TST_TOTAL = 1;
-int fildes;			/* file descriptor for tempfile */
-char *write_buf[NBUFS];		/* buffer to hold data to be written */
+static char *TCID = "pwrite01";
+static int TST_TOTAL = 1;
+static int fildes;			/* file descriptor for tempfile */
+static char *write_buf[NBUFS];		/* buffer to hold data to be written */
 
-void setup();			/* Main setup function of test */
-void cleanup();			/* cleanup function for the test */
-void l_seek(int, off_t, int, off_t);	/* function to call lseek() */
-void init_buffers();		/* function to initialize/allocate buffers */
-void check_file_contents();	/* function to verify the contents of file */
+static void setup();			/* Main setup function of test */
+static void cleanup();			/* cleanup function for the test */
+static void l_seek(int, off_t, int, off_t);	/* function to call lseek() */
+static void init_buffers();		/* function to initialize/allocate buffers */
+static void check_file_contents();	/* function to verify the contents of file */
 
 int main(int ac, char **av)
 {
@@ -199,7 +199,7 @@ int main(int ac, char **av)
  *  Initialize/allocate read/write buffers.
  *  Create a temporary directory and a file under it and
  */
-void setup(void)
+static void setup(void)
 {
 
 	tst_sig(NOFORK, DEF_HANDLER, cleanup);
@@ -226,7 +226,7 @@ void setup(void)
  *    write_buf[0] has 0's, write_buf[1] has 1's, write_buf[2] has 2's
  *    write_buf[3] has 3's.
  */
-void init_buffers(void)
+static void init_buffers(void)
 {
 	int count;		/* counter variable for loop */
 
@@ -247,7 +247,7 @@ void init_buffers(void)
  *  "checkoff" is the offset at which we believe we should be at.
  *  Used to validate pread/pwrite don't move the offset.
  */
-void l_seek(int fdesc, off_t offset, int whence, off_t checkoff)
+static void l_seek(int fdesc, off_t offset, int whence, off_t checkoff)
 {
 	off_t offloc;		/* offset ret. from lseek() */
 
@@ -265,7 +265,7 @@ void l_seek(int fdesc, off_t offset, int whence, off_t checkoff)
  *  The contents of the file are verified by using a plain read() and
  *  Compare the data read with the original write_buf[] contents.
  */
-void check_file_contents(void)
+static void check_file_contents(void)
 {
 	int count, err_flg = 0;	/* index variable and error flag */
 	int nread;		/* return value of read() */
@@ -319,7 +319,7 @@ void check_file_contents(void)
  * Close the temporary file.
  * Remove the temporary directory created.
  */
-void cleanup(void)
+static void cleanup(void)
 {
 	int count;
 

--- a/testcases/kernel/syscalls/pwrite/pwrite04.c
+++ b/testcases/kernel/syscalls/pwrite/pwrite04.c
@@ -40,14 +40,14 @@
 #include <errno.h>
 #include "test.h"
 
-char *TCID = "pwrite04";
-int TST_TOTAL = 1;
-int local_flag;
+static char *TCID = "pwrite04";
+static int TST_TOTAL = 1;
+static int local_flag;
 
 #define PASSED 1
 #define FAILED 0
 
-int block_cnt = 0;
+static int block_cnt = 0;
 
 #define K1    		1024
 #define K2    		(K1 * 2)
@@ -57,7 +57,7 @@ int block_cnt = 0;
 #define	NBUFS 		4
 #define DATA_FILE	"pwrite04_file"
 
-char name[256], fname[256];
+static char name[256], fname[256];
 
 void init_buffers(char *[]);
 void l_seek(int, off_t, int, off_t);
@@ -259,7 +259,7 @@ void l_seek(int fdesc, off_t offset, int whence, off_t checkoff)
  *	created during setup().
  *	Exit the test program with normal exit code.
  */
-void cleanup(void)
+static void cleanup(void)
 {
 
 	tst_rmdir();

--- a/testcases/kernel/syscalls/read/read04.c
+++ b/testcases/kernel/syscalls/read/read04.c
@@ -53,16 +53,16 @@
 #include "test.h"
 #include "safe_macros.h"
 
-void cleanup(void);
-void setup(void);
+static void cleanup(void);
+static void setup(void);
 
-char *TCID = "read04";
-int TST_TOTAL = 1;
+static char *TCID = "read04";
+static int TST_TOTAL = 1;
 
 #define TST_SIZE	27	/* could also do strlen(palfa) */
-char fname[255];
-char palfa[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
-int fild;
+static char fname[255];
+static char palfa[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+static int fild;
 
 int main(int ac, char **av)
 {
@@ -114,7 +114,7 @@ int main(int ac, char **av)
 /*
  * setup() - performs all ONE TIME setup for this test
  */
-void setup(void)
+static void setup(void)
 {
 
 	tst_sig(NOFORK, DEF_HANDLER, cleanup);
@@ -141,7 +141,7 @@ void setup(void)
  * cleanup() - performs all ONE TIME cleanup for this test at completion or
  *	       premature exit.
  */
-void cleanup(void)
+static void cleanup(void)
 {
 
 	unlink(fname);

--- a/testcases/kernel/syscalls/readdir/readdir01.c
+++ b/testcases/kernel/syscalls/readdir/readdir01.c
@@ -121,23 +121,23 @@
   * steps are usually put in separate functions for clarity.  The help function
   * is only needed when you are adding new command line options.
   */
-void setup();
-void help();
-void cleanup();
+static void setup();
+static void help();
+static void cleanup();
 
-char *TCID = "readdir01";
-int TST_TOTAL = 2;
+static char *TCID = "readdir01";
+static int TST_TOTAL = 2;
 
 #define BASENAME	"readdirfile"
 
-char Basename[255];
-char Fname[255];
-int Nfiles = 0;
+static char Basename[255];
+static char Fname[255];
+static int Nfiles = 0;
 
-char *Nfilearg;
-int Nflag = 0;
+static char *Nfilearg;
+static int Nflag = 0;
 
-option_t options[] = {
+static option_t options[] = {
 	{"N:", &Nflag, &Nfilearg},	/* -N #files */
 	{NULL, NULL, NULL}
 };
@@ -270,7 +270,7 @@ int main(int ac, char **av)
  * standard out.  Your help function will be called after the standard options
  * have been printed
  */
-void help(void)
+static void help(void)
 {
 	printf("  -N #files : create #files files every iteration\n");
 }
@@ -278,7 +278,7 @@ void help(void)
 /***************************************************************
  * setup() - performs all ONE TIME setup for this test.
  ***************************************************************/
-void setup(void)
+static void setup(void)
 {
 	/* You will want to enable some signal handling so you can capture
 	 * unexpected signals like SIGSEGV.
@@ -305,7 +305,7 @@ void setup(void)
  * cleanup() - performs all ONE TIME cleanup for this test at
  *		completion or premature exit.
  ***************************************************************/
-void cleanup(void)
+static void cleanup(void)
 {
 
 	/* If you use a temporary directory, you need to be sure you remove it. Use

--- a/testcases/kernel/syscalls/readdir/readdir21.c
+++ b/testcases/kernel/syscalls/readdir/readdir21.c
@@ -43,7 +43,7 @@
 #include "lapi/syscalls.h"
 #include "lapi/readdir.h"
 
-char *TCID = "readdir21";
+static char *TCID = "readdir21";
 
 #define TEST_DIR	"test_dir"
 #define TEST_DIR4	"test_dir4"
@@ -73,7 +73,7 @@ static struct test_case_t {
 #endif
 };
 
-int TST_TOTAL = ARRAY_SIZE(test_cases);
+static int TST_TOTAL = ARRAY_SIZE(test_cases);
 static void readdir_verify(const struct test_case_t *);
 
 int main(int argc, char **argv)

--- a/testcases/kernel/syscalls/readlinkat/readlinkat01.c
+++ b/testcases/kernel/syscalls/readlinkat/readlinkat01.c
@@ -40,7 +40,7 @@
 static void setup(void);
 static void cleanup(void);
 
-char *TCID = "readlinkat01";
+static char *TCID = "readlinkat01";
 
 static int dir_fd, fd;
 static int fd_invalid = 100;
@@ -65,7 +65,7 @@ static struct test_case {
 	{&fd_atcwd, TEST_SYMLINK, TEST_FILE, sizeof(TEST_FILE)-1, 0},
 };
 
-int TST_TOTAL = ARRAY_SIZE(test_cases);
+static int TST_TOTAL = ARRAY_SIZE(test_cases);
 
 static void verify_readlinkat(struct test_case *test)
 {

--- a/testcases/kernel/syscalls/readlinkat/readlinkat02.c
+++ b/testcases/kernel/syscalls/readlinkat/readlinkat02.c
@@ -55,8 +55,8 @@ static struct test_case_t {
 	{&dir_fd, "test_file/test_file", BUFF_SIZE, ENOTDIR},
 };
 
-char *TCID = "readlinkat02";
-int TST_TOTAL = ARRAY_SIZE(test_cases);
+static char *TCID = "readlinkat02";
+static int TST_TOTAL = ARRAY_SIZE(test_cases);
 static void setup(void);
 static void cleanup(void);
 static void readlinkat_verify(const struct test_case_t *);

--- a/testcases/kernel/syscalls/readv/readv02.c
+++ b/testcases/kernel/syscalls/readv/readv02.c
@@ -58,9 +58,9 @@
 #define	MAX_IOVEC	16
 #define DATA_FILE	"readv_data_file"
 
-char buf1[K_1], buf2[K_1], buf3[K_1];
+static char buf1[K_1], buf2[K_1], buf3[K_1];
 
-struct iovec rd_iovec[MAX_IOVEC] = {
+static struct iovec rd_iovec[MAX_IOVEC] = {
 	/* iov_base *//* iov_len */
 
 	/* Test case #1 */
@@ -82,22 +82,22 @@ struct iovec rd_iovec[MAX_IOVEC] = {
 	{(buf2 + CHUNK * 9), CHUNK}
 };
 
-char f_name[K_1];
+static char f_name[K_1];
 
-int fd[4];
-char *buf_list[NBUFS];
+static int fd[4];
+static char *buf_list[NBUFS];
 
-char *TCID = "readv02";
-int TST_TOTAL = 1;
+static char *TCID = "readv02";
+static int TST_TOTAL = 1;
 
-char *bad_addr = 0;
+static char *bad_addr = 0;
 
-int init_buffs(char **);
-int fill_mem(char *, int, int);
-long l_seek(int, long, int);
+static int init_buffs(char **);
+static int fill_mem(char *, int, int);
+static long l_seek(int, long, int);
 char *getenv();
-void setup();
-void cleanup();
+static void setup();
+static void cleanup();
 
 int main(int ac, char **av)
 {
@@ -183,7 +183,7 @@ int main(int ac, char **av)
 /*
  * setup() - performs all ONE TIME setup for this test.
  */
-void setup(void)
+static void setup(void)
 {
 	int nbytes;
 
@@ -234,14 +234,14 @@ void setup(void)
  * cleanup() - performs all ONE TIME cleanup for this test at
  *	       completion or premature exit.
  */
-void cleanup(void)
+static void cleanup(void)
 {
 	SAFE_UNLINK(NULL, f_name);
 	tst_rmdir();
 
 }
 
-int init_buffs(char *pbufs[])
+static int init_buffs(char *pbufs[])
 {
 	int i;
 
@@ -263,7 +263,7 @@ int init_buffs(char *pbufs[])
 	return 0;
 }
 
-int fill_mem(char *c_ptr, int c1, int c2)
+static int fill_mem(char *c_ptr, int c1, int c2)
 {
 	int count;
 
@@ -277,7 +277,7 @@ int fill_mem(char *c_ptr, int c1, int c2)
 	return 0;
 }
 
-long l_seek(int fdesc, long offset, int whence)
+static long l_seek(int fdesc, long offset, int whence)
 {
 	SAFE_LSEEK(cleanup, fdesc, offset, whence);
 	return 0;

--- a/testcases/kernel/syscalls/readv/readv03.c
+++ b/testcases/kernel/syscalls/readv/readv03.c
@@ -60,21 +60,21 @@
 #define	K_1	1024
 #define MODES   S_IRWXU
 
-char buf1[K_1];
+static char buf1[K_1];
 
-struct iovec rd_iovec[1] = {
+static struct iovec rd_iovec[1] = {
 	{buf1, K_1}
 };
 
-const char *TEST_DIR = "alpha";
-int r_val;
-int fd;
+static const char *TEST_DIR = "alpha";
+static int r_val;
+static int fd;
 
-char *TCID = "readv03";
-int TST_TOTAL = 1;
+static char *TCID = "readv03";
+static int TST_TOTAL = 1;
 
-void setup();
-void cleanup();
+static void setup();
+static void cleanup();
 
 int main(int ac, char **av)
 {
@@ -111,7 +111,7 @@ int main(int ac, char **av)
 /*
  * setup() - performs all ONE TIME setup for this test.
  */
-void setup(void)
+static void setup(void)
 {
 
 	tst_sig(NOFORK, DEF_HANDLER, cleanup);
@@ -140,7 +140,7 @@ void setup(void)
  * cleanup() - performs all ONE TIME cleanup for this test at
  *	       completion or premature exit.
  */
-void cleanup(void)
+static void cleanup(void)
 {
 	SAFE_CLOSE(cleanup, fd);
 	tst_rmdir();

--- a/testcases/kernel/syscalls/removexattr/removexattr01.c
+++ b/testcases/kernel/syscalls/removexattr/removexattr01.c
@@ -34,7 +34,7 @@
 #include "test.h"
 #include "safe_macros.h"
 
-char *TCID = "removexattr01";
+static char *TCID = "removexattr01";
 
 #ifdef HAVE_SYS_XATTR_H
 #define USER_KEY	"user.test"
@@ -45,7 +45,7 @@ static void verify_removexattr(void);
 static void setup(void);
 static void cleanup(void);
 
-int TST_TOTAL = 1;
+static int TST_TOTAL = 1;
 
 int main(int ac, char **av)
 {

--- a/testcases/kernel/syscalls/removexattr/removexattr02.c
+++ b/testcases/kernel/syscalls/removexattr/removexattr02.c
@@ -39,7 +39,7 @@
 #include "test.h"
 #include "safe_macros.h"
 
-char *TCID = "removexattr02";
+static char *TCID = "removexattr02";
 
 #ifdef HAVE_SYS_XATTR_H
 
@@ -60,7 +60,7 @@ static void verify_removexattr(struct test_case *tc);
 static void setup(void);
 static void cleanup(void);
 
-int TST_TOTAL = ARRAY_SIZE(tc);
+static int TST_TOTAL = ARRAY_SIZE(tc);
 
 int main(int ac, char **av)
 {

--- a/testcases/kernel/syscalls/rename/rename01.c
+++ b/testcases/kernel/syscalls/rename/rename01.c
@@ -74,19 +74,19 @@
 #include "test.h"
 #include "safe_macros.h"
 
-void setup();
-void cleanup();
+static void setup();
+static void cleanup();
 
-char *TCID = "rename01";
-int TST_TOTAL = 2;
+static char *TCID = "rename01";
+static int TST_TOTAL = 2;
 
-char fname[255], mname[255];
+static char fname[255], mname[255];
 char fdir[255], mdir[255];
-struct stat buf1;
+static struct stat buf1;
 dev_t f_olddev, d_olddev;
 ino_t f_oldino, d_oldino;
 
-struct test_case_t {
+static struct test_case_t {
 	char *name1;
 	char *name2;
 	char *desc;
@@ -173,7 +173,7 @@ int main(int ac, char **av)
 /*
  * setup() - performs all ONE TIME setup for this test.
  */
-void setup(void)
+static void setup(void)
 {
 
 	tst_sig(NOFORK, DEF_HANDLER, cleanup);
@@ -208,7 +208,7 @@ void setup(void)
  * cleanup() - performs all ONE TIME cleanup for this test at
  *             completion or premature exit.
  */
-void cleanup(void)
+static void cleanup(void)
 {
 
 	/*

--- a/testcases/kernel/syscalls/rename/rename02.c
+++ b/testcases/kernel/syscalls/rename/rename02.c
@@ -116,14 +116,14 @@
 #include <signal.h>
 #include "test.h"
 
-void setup();
-void cleanup();
+static void setup();
+static void cleanup();
 
-char *TCID = "rename02";
-int TST_TOTAL = 1;
+static char *TCID = "rename02";
+static int TST_TOTAL = 1;
 
-int fd;
-char fname[255], mname[255];
+static int fd;
+static char fname[255], mname[255];
 
 int main(int ac, char **av)
 {
@@ -167,7 +167,7 @@ int main(int ac, char **av)
 /***************************************************************
  * setup() - performs all ONE TIME setup for this test.
  ***************************************************************/
-void setup(void)
+static void setup(void)
 {
 
 	tst_sig(NOFORK, DEF_HANDLER, cleanup);
@@ -185,7 +185,7 @@ void setup(void)
  * cleanup() - performs all ONE TIME cleanup for this test at
  *		completion or premature exit.
  ***************************************************************/
-void cleanup(void)
+static void cleanup(void)
 {
 
 	tst_rmdir();

--- a/testcases/kernel/syscalls/rename/rename03.c
+++ b/testcases/kernel/syscalls/rename/rename03.c
@@ -71,20 +71,20 @@
 #include "test.h"
 #include "safe_macros.h"
 
-void setup();
-void setup2();
-void cleanup();
+static void setup();
+static void setup2();
+static void cleanup();
 
-char *TCID = "rename03";
-int TST_TOTAL = 2;
+static char *TCID = "rename03";
+static int TST_TOTAL = 2;
 
-char fname[255], mname[255];
-char fdir[255], mdir[255];
-struct stat buf1, buf2;
-dev_t f_olddev, d_olddev;
-ino_t f_oldino, d_oldino;
+static char fname[255], mname[255];
+static char fdir[255], mdir[255];
+static struct stat buf1, buf2;
+static dev_t f_olddev, d_olddev;
+static ino_t f_oldino, d_oldino;
 
-struct test_case_t {
+static struct test_case_t {
 	char *name1;
 	char *name2;
 	char *desc;
@@ -174,7 +174,7 @@ int main(int ac, char **av)
 /*
  * setup() - performs all ONE TIME setup for this test.
  */
-void setup(void)
+static void setup(void)
 {
 
 	tst_sig(NOFORK, DEF_HANDLER, cleanup);
@@ -193,7 +193,7 @@ void setup(void)
 /*
  * setup2() - set up the files and directories for the tests
  */
-void setup2(void)
+static void setup2(void)
 {
 	SAFE_TOUCH(cleanup, fname, 0700, NULL);
 
@@ -220,7 +220,7 @@ void setup2(void)
  * cleanup() - performs all ONE TIME cleanup for this test at
  *             completion or premature exit.
  */
-void cleanup(void)
+static void cleanup(void)
 {
 
 	/*

--- a/testcases/kernel/syscalls/rename/rename11.c
+++ b/testcases/kernel/syscalls/rename/rename11.c
@@ -39,7 +39,7 @@
 #include "test.h"
 #include "safe_macros.h"
 
-char *TCID = "rename11";
+static char *TCID = "rename11";
 
 #define MNTPOINT	"mntpoint"
 #define TEST_EROFS	"mntpoint/test_erofs"
@@ -65,7 +65,7 @@ static void test_emlink(void);
 
 static void (*testfunc[])(void) = { test_eloop, test_erofs, test_emlink };
 
-int TST_TOTAL = ARRAY_SIZE(testfunc);
+static int TST_TOTAL = ARRAY_SIZE(testfunc);
 
 int main(int ac, char **av)
 {

--- a/testcases/kernel/syscalls/rename/rename13.c
+++ b/testcases/kernel/syscalls/rename/rename13.c
@@ -67,17 +67,17 @@
 #include "test.h"
 #include "safe_macros.h"
 
-void setup();
-void cleanup();
+static void setup();
+static void cleanup();
 
-char *TCID = "rename13";
-int TST_TOTAL = 1;
+static char *TCID = "rename13";
+static int TST_TOTAL = 1;
 
-int fd;
-char fname[255], mname[255];
-struct stat buf1, buf2;
-dev_t olddev;
-ino_t oldino;
+static int fd;
+static char fname[255], mname[255];
+static struct stat buf1, buf2;
+static dev_t olddev;
+static ino_t oldino;
 
 int main(int ac, char **av)
 {

--- a/testcases/kernel/syscalls/rename/rename14.c
+++ b/testcases/kernel/syscalls/rename/rename14.c
@@ -48,20 +48,20 @@
 #define FAILED 0
 #define PASSED 1
 
-int local_flag = PASSED;
+static int local_flag = PASSED;
 
-char *TCID = "rename14";
-int TST_TOTAL = 1;
+static char *TCID = "rename14";
+static int TST_TOTAL = 1;
 
 #define RUNTIME	5
 
-int kidpid[2];
-int parent_pid;
+static int kidpid[2];
+static int parent_pid;
 
-int term(void);
-int al(void);
-void dochild1(void);
-void dochild2(void);
+static int term(void);
+static int al(void);
+static void dochild1(void);
+static void dochild2(void);
 
 int main(int argc, char *argv[])
 {
@@ -139,7 +139,7 @@ int term(void)
 	return 0;
 }
 
-int al(void)
+static int al(void)
 {
 	if (kidpid[0])
 		return (kill(kidpid[0], SIGTERM));
@@ -148,7 +148,7 @@ int al(void)
 	return 0;
 }
 
-void dochild1(void)
+static void dochild1(void)
 {
 	int fd;
 
@@ -159,7 +159,7 @@ void dochild1(void)
 	}
 }
 
-void dochild2(void)
+static void dochild2(void)
 {
 	for (;;)
 		rename("./rename14", "./rename14xyz");

--- a/testcases/kernel/syscalls/renameat/renameat01.c
+++ b/testcases/kernel/syscalls/renameat/renameat01.c
@@ -106,8 +106,8 @@ static void setup(void);
 static void cleanup(void);
 static void renameat_verify(const struct test_case_t *);
 
-char *TCID = "renameat01";
-int TST_TOTAL = ARRAY_SIZE(test_cases);
+static char *TCID = "renameat01";
+static int TST_TOTAL = ARRAY_SIZE(test_cases);
 
 int main(int ac, char **av)
 {

--- a/testcases/kernel/syscalls/renameat2/renameat201.c
+++ b/testcases/kernel/syscalls/renameat2/renameat201.c
@@ -47,7 +47,7 @@
 #define TEST_FILE3 "test_file3"
 #define NON_EXIST "non_exist"
 
-char *TCID = "renameat201";
+static char *TCID = "renameat201";
 
 static int olddirfd;
 static int newdirfd;
@@ -71,7 +71,7 @@ static struct test_case {
 				| RENAME_EXCHANGE, EINVAL}
 };
 
-int TST_TOTAL = ARRAY_SIZE(test_cases);
+static int TST_TOTAL = ARRAY_SIZE(test_cases);
 
 static void setup(void);
 static void cleanup(void);

--- a/testcases/kernel/syscalls/renameat2/renameat202.c
+++ b/testcases/kernel/syscalls/renameat2/renameat202.c
@@ -34,7 +34,7 @@
 #define TEST_FILE "test_file"
 #define TEST_FILE2 "test_file2"
 
-char *TCID = "renameat202";
+static char *TCID = "renameat202";
 
 static int olddirfd;
 static int newdirfd;
@@ -45,7 +45,7 @@ static const char content[] = "content";
 static long fs_type;
 
 
-int TST_TOTAL = 1;
+static int TST_TOTAL = 1;
 
 static void setup(void);
 static void cleanup(void);

--- a/testcases/kernel/syscalls/rt_sigprocmask/rt_sigprocmask02.c
+++ b/testcases/kernel/syscalls/rt_sigprocmask/rt_sigprocmask02.c
@@ -59,8 +59,8 @@
 #include "lapi/syscalls.h"
 #include "ltp_signal.h"
 
-char *TCID = "rt_sigprocmask02";
-int TST_TOTAL = 2;
+static char *TCID = "rt_sigprocmask02";
+static int TST_TOTAL = 2;
 
 static void cleanup(void)
 {
@@ -85,7 +85,7 @@ static struct test_case_t {
 	(sigset_t *) - 1, SIGSETSIZE, EFAULT}
 };
 
-int test_count = sizeof(test_cases) / sizeof(struct test_case_t);
+static int test_count = sizeof(test_cases) / sizeof(struct test_case_t);
 
 int main(int ac, char **av)
 {

--- a/testcases/kernel/syscalls/sbrk/sbrk01.c
+++ b/testcases/kernel/syscalls/sbrk/sbrk01.c
@@ -46,7 +46,7 @@
 
 #include "test.h"
 
-char *TCID = "sbrk01";
+static char *TCID = "sbrk01";
 
 static struct test_case_t {
 	long increment;
@@ -59,7 +59,7 @@ static void setup(void);
 static void sbrk_verify(const struct test_case_t *);
 static void cleanup(void);
 
-int TST_TOTAL = ARRAY_SIZE(test_cases);
+static int TST_TOTAL = ARRAY_SIZE(test_cases);
 
 int main(int ac, char **av)
 {

--- a/testcases/kernel/syscalls/sbrk/sbrk02.c
+++ b/testcases/kernel/syscalls/sbrk/sbrk02.c
@@ -25,8 +25,8 @@
 
 #define INC 16*1024*1024
 
-char *TCID = "sbrk02";
-int TST_TOTAL = 1;
+static char *TCID = "sbrk02";
+static int TST_TOTAL = 1;
 
 static void setup(void);
 static void sbrk_verify(void);

--- a/testcases/kernel/syscalls/sched_getattr/sched_getattr01.c
+++ b/testcases/kernel/syscalls/sched_getattr/sched_getattr01.c
@@ -29,15 +29,15 @@
 #include "lapi/syscalls.h"
 #include "lapi/sched.h"
 
-char *TCID = "sched_getattr01";
-int TST_TOTAL = 1;
+static char *TCID = "sched_getattr01";
+static int TST_TOTAL = 1;
 
 #define SCHED_DEADLINE	6
 #define RUNTIME_VAL 10000000
 #define PERIOD_VAL 30000000
 #define DEADLINE_VAL 30000000
 
-void *run_deadline(void *data LTP_ATTRIBUTE_UNUSED)
+static void *run_deadline(void *data LTP_ATTRIBUTE_UNUSED)
 {
 	struct sched_attr attr, attr_copy;
 	int ret;

--- a/testcases/kernel/syscalls/sched_getattr/sched_getattr02.c
+++ b/testcases/kernel/syscalls/sched_getattr/sched_getattr02.c
@@ -38,7 +38,7 @@
 #include "lapi/syscalls.h"
 #include "lapi/sched.h"
 
-char *TCID = "sched_getattr02";
+static char *TCID = "sched_getattr02";
 
 static pid_t pid;
 static pid_t unused_pid;
@@ -60,7 +60,7 @@ static struct test_case {
 static void setup(void);
 static void sched_getattr_verify(const struct test_case *test);
 
-int TST_TOTAL = ARRAY_SIZE(test_cases);
+static int TST_TOTAL = ARRAY_SIZE(test_cases);
 
 static void sched_getattr_verify(const struct test_case *test)
 {
@@ -99,7 +99,7 @@ int main(int argc, char **argv)
 	tst_exit();
 }
 
-void setup(void)
+static void setup(void)
 {
 	unused_pid = tst_get_unused_pid(setup);
 

--- a/testcases/kernel/syscalls/sched_getscheduler/sched_getscheduler01.c
+++ b/testcases/kernel/syscalls/sched_getscheduler/sched_getscheduler01.c
@@ -50,13 +50,13 @@
 #include <stdio.h>
 #include "test.h"
 
-char *TCID = "sched_getscheduler01";
-int TST_TOTAL = 3;
+static char *TCID = "sched_getscheduler01";
+static int TST_TOTAL = 3;
 
-void setup(void);
-void cleanup(void);
+static void setup(void);
+static void cleanup(void);
 
-struct test_case_t {
+static struct test_case_t {
 	int prio;
 	int policy;
 } TC[] = {
@@ -114,7 +114,7 @@ int main(int ac, char **av)
 	tst_exit();
 }
 
-void setup(void)
+static void setup(void)
 {
 
 	tst_require_root();
@@ -124,6 +124,6 @@ void setup(void)
 	TEST_PAUSE;
 }
 
-void cleanup(void)
+static void cleanup(void)
 {
 }

--- a/testcases/kernel/syscalls/sched_setattr/sched_setattr01.c
+++ b/testcases/kernel/syscalls/sched_setattr/sched_setattr01.c
@@ -35,7 +35,7 @@
 #include "test.h"
 #include "lapi/sched.h"
 
-char *TCID = "sched_setattr01";
+static char *TCID = "sched_setattr01";
 
 #define SCHED_DEADLINE	6
 #define RUNTIME_VAL 10000000
@@ -73,7 +73,7 @@ static struct test_case {
 static void setup(void);
 static void sched_setattr_verify(const struct test_case *test);
 
-int TST_TOTAL = ARRAY_SIZE(test_cases);
+static int TST_TOTAL = ARRAY_SIZE(test_cases);
 
 void *do_test(void *data LTP_ATTRIBUTE_UNUSED)
 {
@@ -126,7 +126,7 @@ int main(int argc, char **argv)
 	tst_exit();
 }
 
-void setup(void)
+static void setup(void)
 {
 	unused_pid = tst_get_unused_pid(setup);
 

--- a/testcases/kernel/syscalls/sched_yield/sched_yield01.c
+++ b/testcases/kernel/syscalls/sched_yield/sched_yield01.c
@@ -47,11 +47,11 @@
 #include <errno.h>
 #include "test.h"
 
-char *TCID = "sched_yield01";
-int TST_TOTAL = 1;
+static char *TCID = "sched_yield01";
+static int TST_TOTAL = 1;
 
-void setup(void);
-void cleanup(void);
+static void setup(void);
+static void cleanup(void);
 
 int main(int ac, char **av)
 {
@@ -83,7 +83,7 @@ int main(int ac, char **av)
 /*
  * setup() - performs all ONE TIME setup for this test.
  */
-void setup(void)
+static void setup(void)
 {
 
 	tst_sig(NOFORK, DEF_HANDLER, cleanup);
@@ -95,7 +95,7 @@ void setup(void)
  * cleanup() - performs all ONE TIME cleanup for this test at
  *	       completion or premature exit.
  */
-void cleanup(void)
+static void cleanup(void)
 {
 
 }

--- a/testcases/kernel/syscalls/select/select01.c
+++ b/testcases/kernel/syscalls/select/select01.c
@@ -53,11 +53,11 @@
 static void setup(void);
 static void cleanup(void);
 
-char *TCID = "select01";
-int TST_TOTAL = 1;
+static char *TCID = "select01";
+static int TST_TOTAL = 1;
 
-int Fd = -1;
-fd_set Readfds;
+static int Fd = -1;
+static fd_set Readfds;
 
 int main(int ac, char **av)
 {

--- a/testcases/kernel/syscalls/select/select02.c
+++ b/testcases/kernel/syscalls/select/select02.c
@@ -51,12 +51,12 @@
 
 static void setup(void);
 
-char *TCID = "select02";
-int TST_TOTAL = 1;
+static char *TCID = "select02";
+static int TST_TOTAL = 1;
 
-int Fd[2];
-fd_set saved_Readfds, saved_Writefds;
-fd_set Readfds, Writefds;
+static int Fd[2];
+static fd_set saved_Readfds, saved_Writefds;
+static fd_set Readfds, Writefds;
 
 int main(int ac, char **av)
 {

--- a/testcases/kernel/syscalls/select/select03.c
+++ b/testcases/kernel/syscalls/select/select03.c
@@ -55,12 +55,12 @@
 static void setup(void);
 static void cleanup(void);
 
-char *TCID = "select03";
-int TST_TOTAL = 1;
+static char *TCID = "select03";
+static int TST_TOTAL = 1;
 
-int Fd;
-fd_set saved_Readfds, saved_Writefds;
-fd_set Readfds, Writefds;
+static int Fd;
+static fd_set saved_Readfds, saved_Writefds;
+static fd_set Readfds, Writefds;
 
 int main(int ac, char **av)
 {

--- a/testcases/kernel/syscalls/send/send01.c
+++ b/testcases/kernel/syscalls/send/send01.c
@@ -44,8 +44,8 @@
 #include "test.h"
 #include "safe_macros.h"
 
-char *TCID = "send01";
-int testno;
+static char *TCID = "send01";
+static int testno;
 
 static char buf[1024], bigbuf[128 * 1024];
 static int s;
@@ -155,7 +155,7 @@ static struct test_case_t tdat[] = {
 #endif
 };
 
-int TST_TOTAL = sizeof(tdat) / sizeof(tdat[0]);
+static int TST_TOTAL = sizeof(tdat) / sizeof(tdat[0]);
 
 #ifdef UCLINUX
 static char *argv0;

--- a/testcases/kernel/syscalls/sendfile/sendfile02.c
+++ b/testcases/kernel/syscalls/sendfile/sendfile02.c
@@ -64,21 +64,21 @@
 #endif /* Not def: OFF_T */
 
 TCID_DEFINE(sendfile02);
-int TST_TOTAL = 4;
+static int TST_TOTAL = 4;
 
-char in_file[100];
-char out_file[100];
-int out_fd;
-pid_t child_pid;
+static char in_file[100];
+static char out_file[100];
+static int out_fd;
+static pid_t child_pid;
 static int sockfd, s;
 static struct sockaddr_in sin1;	/* shared between do_child and create_server */
 
-void cleanup(void);
-void do_child(void);
-void setup(void);
-int create_server(void);
+static void cleanup(void);
+static void do_child(void);
+static void setup(void);
+static int create_server(void);
 
-struct test_case_t {
+static struct test_case_t {
 	char *desc;
 	int offset;
 	int exp_retval;
@@ -95,7 +95,7 @@ struct test_case_t {
 static char *argv0;
 #endif
 
-void do_sendfile(OFF_T offset, int i)
+static void do_sendfile(OFF_T offset, int i)
 {
 	int in_fd;
 	struct stat sb;
@@ -154,7 +154,7 @@ void do_sendfile(OFF_T offset, int i)
 /*
  * do_child
  */
-void do_child(void)
+static void do_child(void)
 {
 	int lc;
 	socklen_t length;
@@ -171,7 +171,7 @@ void do_child(void)
 /*
  * setup() - performs all ONE TIME setup for this test.
  */
-void setup(void)
+static void setup(void)
 {
 	int fd;
 	char buf[100];
@@ -199,7 +199,7 @@ void setup(void)
  * cleanup() - performs all ONE TIME cleanup for this test at
  *	       completion or premature exit.
  */
-void cleanup(void)
+static void cleanup(void)
 {
 
 	close(out_fd);
@@ -208,7 +208,7 @@ void cleanup(void)
 
 }
 
-int create_server(void)
+static int create_server(void)
 {
 	static int count = 0;
 	socklen_t slen = sizeof(sin1);

--- a/testcases/kernel/syscalls/sendfile/sendfile04.c
+++ b/testcases/kernel/syscalls/sendfile/sendfile04.c
@@ -65,22 +65,22 @@
 
 TCID_DEFINE(sendfile04);
 
-char in_file[100];
-char out_file[100];
-int out_fd;
-pid_t child_pid;
+static char in_file[100];
+static char out_file[100];
+static int out_fd;
+static pid_t child_pid;
 static int sockfd, s;
 static struct sockaddr_in sin1;	/* shared between do_child and create_server */
 
-void cleanup(void);
-void do_child(void);
-void setup(void);
-int create_server(void);
+static void cleanup(void);
+static void do_child(void);
+static void setup(void);
+static int create_server(void);
 
 #define PASS_MAPPED_BUFFER 0
 #define PASS_UNMAPPED_BUFFER 1
 
-struct test_case_t {
+static struct test_case_t {
 	int protection;
 	int pass_unmapped_buffer;
 } testcases[] = {
@@ -91,13 +91,13 @@ struct test_case_t {
 	PROT_EXEC | PROT_READ, PASS_MAPPED_BUFFER}, {
 PROT_READ | PROT_WRITE, PASS_UNMAPPED_BUFFER},};
 
-int TST_TOTAL = sizeof(testcases) / sizeof(testcases[0]);
+static int TST_TOTAL = sizeof(testcases) / sizeof(testcases[0]);
 
 #ifdef UCLINUX
 static char *argv0;
 #endif
 
-void do_sendfile(int prot, int pass_unmapped_buffer)
+static void do_sendfile(int prot, int pass_unmapped_buffer)
 {
 	OFF_T *protected_buffer;
 	int in_fd;
@@ -151,7 +151,7 @@ void do_sendfile(int prot, int pass_unmapped_buffer)
 /*
  * do_child
  */
-void do_child(void)
+static void do_child(void)
 {
 	int lc;
 	socklen_t length;
@@ -168,7 +168,7 @@ void do_child(void)
 /*
  * setup() - performs all ONE TIME setup for this test.
  */
-void setup(void)
+static void setup(void)
 {
 	int fd;
 	char buf[100];
@@ -196,7 +196,7 @@ void setup(void)
  * cleanup() - performs all ONE TIME cleanup for this test at
  *	       completion or premature exit.
  */
-void cleanup(void)
+static void cleanup(void)
 {
 
 	close(out_fd);
@@ -205,7 +205,7 @@ void cleanup(void)
 
 }
 
-int create_server(void)
+static int create_server(void)
 {
 	static int count = 0;
 	socklen_t slen = sizeof(sin1);

--- a/testcases/kernel/syscalls/sendfile/sendfile05.c
+++ b/testcases/kernel/syscalls/sendfile/sendfile05.c
@@ -60,25 +60,25 @@
 
 TCID_DEFINE(sendfile05);
 
-char in_file[100];
-char out_file[100];
-int out_fd;
-pid_t child_pid;
+static char in_file[100];
+static char out_file[100];
+static int out_fd;
+static pid_t child_pid;
 static int sockfd, s;
 static struct sockaddr_in sin1;	/* shared between do_child and create_server */
 
-void cleanup(void);
-void do_child(void);
-void setup(void);
-int create_server(void);
+static void cleanup(void);
+static void do_child(void);
+static void setup(void);
+static int create_server(void);
 
-int TST_TOTAL = 1;
+static int TST_TOTAL = 1;
 
 #ifdef UCLINUX
 static char *argv0;
 #endif
 
-void do_sendfile(void)
+static void do_sendfile(void)
 {
 	OFF_T offset;
 	int in_fd;
@@ -116,7 +116,7 @@ void do_sendfile(void)
 /*
  * do_child
  */
-void do_child(void)
+static void do_child(void)
 {
 	int lc;
 	socklen_t length;
@@ -133,7 +133,7 @@ void do_child(void)
 /*
  * setup() - performs all ONE TIME setup for this test.
  */
-void setup(void)
+static void setup(void)
 {
 	int fd;
 	char buf[100];
@@ -161,7 +161,7 @@ void setup(void)
  * cleanup() - performs all ONE TIME cleanup for this test at
  *	       completion or premature exit.
  */
-void cleanup(void)
+static void cleanup(void)
 {
 
 	close(out_fd);
@@ -170,7 +170,7 @@ void cleanup(void)
 
 }
 
-int create_server(void)
+static int create_server(void)
 {
 	static int count = 0;
 	socklen_t slen = sizeof(sin1);

--- a/testcases/kernel/syscalls/sendfile/sendfile06.c
+++ b/testcases/kernel/syscalls/sendfile/sendfile06.c
@@ -57,7 +57,7 @@ static void do_child(void);
 static void setup(void);
 static int create_server(void);
 
-int TST_TOTAL = 1;
+static int TST_TOTAL = 1;
 
 #ifdef UCLINUX
 static char *argv0;

--- a/testcases/kernel/syscalls/sendfile/sendfile08.c
+++ b/testcases/kernel/syscalls/sendfile/sendfile08.c
@@ -41,7 +41,7 @@
 #define TEST_MSG_ALL (TEST_MSG_OUT TEST_MSG_IN)
 
 TCID_DEFINE(sendfile08);
-int TST_TOTAL = 1;
+static int TST_TOTAL = 1;
 
 static int in_fd;
 static int out_fd;

--- a/testcases/kernel/syscalls/sendmsg/sendmsg01.c
+++ b/testcases/kernel/syscalls/sendmsg/sendmsg01.c
@@ -50,8 +50,8 @@
 #include "test.h"
 #include "safe_macros.h"
 
-char *TCID = "sendmsg01";
-int testno;
+static char *TCID = "sendmsg01";
+static int testno;
 
 static char buf[1024], bigbuf[128 * 1024];
 static int s;
@@ -101,7 +101,7 @@ struct test_case_t {		/* test case structure */
 	char *desc;
 };
 
-struct test_case_t tdat[] = {
+static struct test_case_t tdat[] = {
 	{.domain = PF_INET,
 	 .type = SOCK_STREAM,
 	 .proto = 0,
@@ -356,7 +356,7 @@ struct test_case_t tdat[] = {
 	 .desc = "invalid cmsg pointer"}
 };
 
-int TST_TOTAL = sizeof(tdat) / sizeof(tdat[0]);
+static int TST_TOTAL = sizeof(tdat) / sizeof(tdat[0]);
 
 #ifdef UCLINUX
 static char *argv0;

--- a/testcases/kernel/syscalls/sendto/sendto01.c
+++ b/testcases/kernel/syscalls/sendto/sendto01.c
@@ -43,8 +43,8 @@
 #include "test.h"
 #include "safe_macros.h"
 
-char *TCID = "sendto01";
-int testno;
+static char *TCID = "sendto01";
+static int testno;
 
 static char buf[1024], bigbuf[128 * 1024];
 static int s;
@@ -77,7 +77,7 @@ static void cleanup0(void);
 static void cleanup1(void);
 static void do_child(void);
 
-struct test_case_t tdat[] = {
+static struct test_case_t tdat[] = {
 	{.domain = PF_INET,
 	 .type = SOCK_STREAM,
 	 .proto = 0,

--- a/testcases/kernel/syscalls/set_thread_area/set_thread_area01.c
+++ b/testcases/kernel/syscalls/set_thread_area/set_thread_area01.c
@@ -21,8 +21,8 @@
 
 #include "set_thread_area.h"
 
-char *TCID = "set_thread_area_01";
-int TST_TOTAL = 6;
+static char *TCID = "set_thread_area_01";
+static int TST_TOTAL = 6;
 
 #if defined(HAVE_ASM_LDT_H) && defined(HAVE_STRUCT_USER_DESC)
 

--- a/testcases/kernel/syscalls/setegid/setegid02.c
+++ b/testcases/kernel/syscalls/setegid/setegid02.c
@@ -25,8 +25,8 @@
 #include "test.h"
 #include "safe_macros.h"
 
-char *TCID = "setegid02";
-int TST_TOTAL = 1;
+static char *TCID = "setegid02";
+static int TST_TOTAL = 1;
 static void setup(void);
 static void setegid_verify(void);
 static void cleanup(void);

--- a/testcases/kernel/syscalls/setfsgid/setfsgid01.c
+++ b/testcases/kernel/syscalls/setfsgid/setfsgid01.c
@@ -31,7 +31,7 @@
 #include "compat_16.h"
 
 TCID_DEFINE(setfsgid01);
-int TST_TOTAL = 1;
+static int TST_TOTAL = 1;
 
 static void setup(void);
 static void cleanup(void);

--- a/testcases/kernel/syscalls/setfsgid/setfsgid02.c
+++ b/testcases/kernel/syscalls/setfsgid/setfsgid02.c
@@ -34,7 +34,7 @@
 #include "compat_16.h"
 
 TCID_DEFINE(setfsgid02);
-int TST_TOTAL = 1;
+static int TST_TOTAL = 1;
 
 static void setup(void);
 static void cleanup(void);

--- a/testcases/kernel/syscalls/setfsgid/setfsgid03.c
+++ b/testcases/kernel/syscalls/setfsgid/setfsgid03.c
@@ -34,7 +34,7 @@
 #include "compat_16.h"
 
 TCID_DEFINE(setfsgid03);
-int TST_TOTAL = 1;
+static int TST_TOTAL = 1;
 
 static char nobody_uid[] = "nobody";
 static struct passwd *ltpuser;

--- a/testcases/kernel/syscalls/setfsuid/setfsuid01.c
+++ b/testcases/kernel/syscalls/setfsuid/setfsuid01.c
@@ -34,7 +34,7 @@ static void setup(void);
 static void cleanup(void);
 
 TCID_DEFINE(setfsuid01);
-int TST_TOTAL = 1;
+static int TST_TOTAL = 1;
 
 int main(int ac, char **av)
 {

--- a/testcases/kernel/syscalls/setfsuid/setfsuid02.c
+++ b/testcases/kernel/syscalls/setfsuid/setfsuid02.c
@@ -36,7 +36,7 @@ static void setup(void);
 static void cleanup(void);
 
 TCID_DEFINE(setfsuid02);
-int TST_TOTAL = 1;
+static int TST_TOTAL = 1;
 
 int main(int ac, char **av)
 {

--- a/testcases/kernel/syscalls/setfsuid/setfsuid03.c
+++ b/testcases/kernel/syscalls/setfsuid/setfsuid03.c
@@ -36,7 +36,7 @@ static void setup(void);
 static void cleanup(void);
 
 TCID_DEFINE(setfsuid03);
-int TST_TOTAL = 1;
+static int TST_TOTAL = 1;
 
 static char nobody_uid[] = "nobody";
 static struct passwd *ltpuser;

--- a/testcases/kernel/syscalls/setfsuid/setfsuid04.c
+++ b/testcases/kernel/syscalls/setfsuid/setfsuid04.c
@@ -42,7 +42,7 @@
 #include "compat_16.h"
 
 TCID_DEFINE(setfsuid04);
-int TST_TOTAL = 1;
+static int TST_TOTAL = 1;
 
 static char nobody_uid[] = "nobody";
 static char testfile[] = "setfsuid04_testfile";

--- a/testcases/kernel/syscalls/setgid/setgid01.c
+++ b/testcases/kernel/syscalls/setgid/setgid01.c
@@ -45,7 +45,7 @@ static void setup(void);
 static void cleanup(void);
 
 TCID_DEFINE(setgid01);
-int TST_TOTAL = 1;
+static int TST_TOTAL = 1;
 
 static gid_t gid;
 

--- a/testcases/kernel/syscalls/setgid/setgid02.c
+++ b/testcases/kernel/syscalls/setgid/setgid02.c
@@ -31,7 +31,7 @@
 #include "compat_16.h"
 
 TCID_DEFINE(setgid02);
-int TST_TOTAL = 1;
+static int TST_TOTAL = 1;
 
 static char root[] = "root";
 static char nobody_uid[] = "nobody";

--- a/testcases/kernel/syscalls/setgid/setgid03.c
+++ b/testcases/kernel/syscalls/setgid/setgid03.c
@@ -28,7 +28,7 @@
 #include <compat_16.h>
 
 TCID_DEFINE(setgid03);
-int TST_TOTAL = 1;
+static int TST_TOTAL = 1;
 
 static char ltpuser1[] = "nobody";
 static char root[] = "root";

--- a/testcases/kernel/syscalls/setitimer/setitimer01.c
+++ b/testcases/kernel/syscalls/setitimer/setitimer01.c
@@ -56,11 +56,11 @@
 #include <errno.h>
 #include <sys/time.h>
 
-void cleanup(void);
-void setup(void);
+static void cleanup(void);
+static void setup(void);
 
-char *TCID = "setitimer01";
-int TST_TOTAL = 1;
+static char *TCID = "setitimer01";
+static int TST_TOTAL = 1;
 
 #define SEC0	0
 #define SEC1	20
@@ -139,7 +139,7 @@ int main(int ac, char **av)
 /*
  * setup() - performs all the ONE TIME setup for this test.
  */
-void setup(void)
+static void setup(void)
 {
 
 	tst_sig(NOFORK, DEF_HANDLER, cleanup);
@@ -151,7 +151,7 @@ void setup(void)
  * cleanup() - performs all the ONE TIME cleanup for this test at completion
  * 	       or premature exit.
  */
-void cleanup(void)
+static void cleanup(void)
 {
 
 }

--- a/testcases/kernel/syscalls/setns/setns01.c
+++ b/testcases/kernel/syscalls/setns/setns01.c
@@ -37,7 +37,7 @@
 #include "lapi/syscalls.h"
 #include "safe_macros.h"
 
-char *TCID = "setns01";
+static char *TCID = "setns01";
 
 #if defined(__NR_setns)
 #include "setns.h"
@@ -63,7 +63,7 @@ static void setup4(struct testcase_t *, int);
 static void cleanup1(struct testcase_t *);
 static void cleanup4(struct testcase_t *);
 
-struct testcase_t tdat[] = {
+static struct testcase_t tdat[] = {
 	{
 		.msg = "invalid fd",
 		.fd = -1,

--- a/testcases/kernel/syscalls/setpgid/setpgid03_child.c
+++ b/testcases/kernel/syscalls/setpgid/setpgid03_child.c
@@ -18,7 +18,7 @@
 
 #include "test.h"
 
-char *TCID = "setpgid03_child";
+static char *TCID = "setpgid03_child";
 
 
 int main(void)

--- a/testcases/kernel/syscalls/setregid/setregid03.c
+++ b/testcases/kernel/syscalls/setregid/setregid03.c
@@ -21,7 +21,7 @@ static gid_t neg_one = -1;
 struct group nobody_gr, daemon_gr, root_gr, bin_gr;
 struct passwd nobody;
 
-struct tcase {
+static struct tcase {
 	gid_t *real_gid;
 	gid_t *eff_gid;
 	int *exp_ret;

--- a/testcases/kernel/syscalls/setregid/setregid04.c
+++ b/testcases/kernel/syscalls/setregid/setregid04.c
@@ -21,7 +21,7 @@ static struct group nobody_gr, daemon_gr, root_gr, bin_gr;
  * is used for a separate test.  The tests are executed in the for loop below.
  */
 
-struct test_data_t {
+static struct test_data_t {
 	gid_t *real_gid;
 	gid_t *eff_gid;
 	struct group *exp_real_usr;

--- a/testcases/kernel/syscalls/setreuid/setreuid01.c
+++ b/testcases/kernel/syscalls/setreuid/setreuid01.c
@@ -49,7 +49,7 @@ static void setup(void);
 static void cleanup(void);
 
 TCID_DEFINE(setreuid01);
-int TST_TOTAL = 5;
+static int TST_TOTAL = 5;
 
 static uid_t ruid, euid;	/* real and effective user ids */
 

--- a/testcases/kernel/syscalls/setreuid/setreuid02.c
+++ b/testcases/kernel/syscalls/setreuid/setreuid02.c
@@ -58,7 +58,7 @@ static struct test_data_t {
 	&bin.pw_uid, &neg_one, &bin, &root, "After setreuid(bin, -1)"}, {
 &root.pw_uid, &neg_one, &root, &root, "After setreuid(-1, root)"},};
 
-int TST_TOTAL = ARRAY_SIZE(test_data);
+static int TST_TOTAL = ARRAY_SIZE(test_data);
 
 static void setup(void);
 static void cleanup(void);

--- a/testcases/kernel/syscalls/setreuid/setreuid03.c
+++ b/testcases/kernel/syscalls/setreuid/setreuid03.c
@@ -84,7 +84,7 @@ static struct test_data_t {
 	&nobody.pw_uid, &bin.pw_uid, &fail, &nobody, &nobody,
 		    "After setreuid(nobody, bin),"},};
 
-int TST_TOTAL = ARRAY_SIZE(test_data);
+static int TST_TOTAL = ARRAY_SIZE(test_data);
 
 static void setup(void);
 static void cleanup(void);

--- a/testcases/kernel/syscalls/setreuid/setreuid04.c
+++ b/testcases/kernel/syscalls/setreuid/setreuid04.c
@@ -42,7 +42,7 @@ static struct passwd nobody, root;
  * is used for a separate test.  The tests are executed in the for loop below.
  */
 
-struct test_data_t {
+static struct test_data_t {
 	uid_t *real_uid;
 	uid_t *eff_uid;
 	struct passwd *exp_real_usr;
@@ -54,7 +54,7 @@ struct test_data_t {
 &nobody.pw_uid, &nobody.pw_uid, &nobody, &nobody,
 		    "After setreuid(-1, -1),"},};
 
-int TST_TOTAL = ARRAY_SIZE(test_data);
+static int TST_TOTAL = ARRAY_SIZE(test_data);
 
 static void setup(void);
 static void cleanup(void);

--- a/testcases/kernel/syscalls/setreuid/setreuid05.c
+++ b/testcases/kernel/syscalls/setreuid/setreuid05.c
@@ -39,7 +39,7 @@ static uid_t neg_one = -1;
 
 static struct passwd nobody, daemonpw, root, bin;
 
-struct test_data_t {
+static struct test_data_t {
 	uid_t *real_uid;
 	uid_t *eff_uid;
 	int *exp_ret;
@@ -76,7 +76,7 @@ struct test_data_t {
 	&neg_one, &bin.pw_uid, &fail, &daemonpw, &daemonpw,
 		    "After setreuid(-1, bin),"},};
 
-int TST_TOTAL = ARRAY_SIZE(test_data);
+static int TST_TOTAL = ARRAY_SIZE(test_data);
 
 static void setup(void);
 static void cleanup(void);

--- a/testcases/kernel/syscalls/setreuid/setreuid06.c
+++ b/testcases/kernel/syscalls/setreuid/setreuid06.c
@@ -39,7 +39,7 @@
 #define INVAL_USER		 (USHRT_MAX-2)
 
 TCID_DEFINE(setreuid06);
-int TST_TOTAL = 1;
+static int TST_TOTAL = 1;
 
 static struct passwd *ltpuser;
 

--- a/testcases/kernel/syscalls/setreuid/setreuid07.c
+++ b/testcases/kernel/syscalls/setreuid/setreuid07.c
@@ -40,7 +40,7 @@
 #include "compat_16.h"
 
 TCID_DEFINE(setreuid07);
-int TST_TOTAL = 1;
+static int TST_TOTAL = 1;
 
 static char testfile[256] = "";
 static struct passwd *ltpuser;

--- a/testcases/kernel/syscalls/settimeofday/settimeofday02.c
+++ b/testcases/kernel/syscalls/settimeofday/settimeofday02.c
@@ -12,7 +12,7 @@
 #include "tst_test.h"
 #include "lapi/syscalls.h"
 
-struct timeval tv_saved;
+static struct timeval tv_saved;
 static int flag;
 
 static struct tcase {

--- a/testcases/kernel/syscalls/sigaction/sigaction01.c
+++ b/testcases/kernel/syscalls/sigaction/sigaction01.c
@@ -70,14 +70,14 @@
 #include <unistd.h>
 #include "test.h"
 
-void setup();
-void cleanup();
+static void setup();
+static void cleanup();
 
-char *TCID = "sigaction01";
-int TST_TOTAL = 4;
+static char *TCID = "sigaction01";
+static int TST_TOTAL = 4;
 
-volatile sig_atomic_t testcase_no;
-volatile sig_atomic_t pass;
+static volatile sig_atomic_t testcase_no;
+static volatile sig_atomic_t pass;
 
 /*
  * handler()
@@ -86,7 +86,7 @@ volatile sig_atomic_t pass;
  * 	being executed and compares the current conditions to the ones it
  * 	expects (based on the test case number).
  */
-void handler(int sig, siginfo_t * sip, void *ucp)
+static void handler(int sig, siginfo_t * sip, void *ucp)
 {
 	struct sigaction oact;
 	int err;
@@ -189,7 +189,7 @@ void handler(int sig, siginfo_t * sip, void *ucp)
  * 	Establish a signal handler for SIGUSR1 with the specified flags and
  * 	signal to mask while the handler executes.
  */
-int set_handler(int flags, int sig_to_mask)
+static int set_handler(int flags, int sig_to_mask)
 {
 	struct sigaction sa;
 
@@ -210,7 +210,7 @@ int set_handler(int flags, int sig_to_mask)
 /*
  * setup() - performs all ONE TIME setup for this test.
  */
-void setup(void)
+static void setup(void)
 {
 
 	TEST_PAUSE;
@@ -220,7 +220,7 @@ void setup(void)
  * cleanup() - performs all ONE TIME cleanup for this test at
  *	       completion or premature exit.
  */
-void cleanup(void)
+static void cleanup(void)
 {
 
 }

--- a/testcases/kernel/syscalls/sigaction/sigaction02.c
+++ b/testcases/kernel/syscalls/sigaction/sigaction02.c
@@ -63,8 +63,8 @@
 void setup();
 void cleanup();
 
-char *TCID = "sigaction02";
-int TST_TOTAL = 1;
+static char *TCID = "sigaction02";
+static int TST_TOTAL = 1;
 
 volatile sig_atomic_t testcase_no;
 
@@ -86,7 +86,7 @@ void handler(int sig)
  * Returns
  *	0 on success, errno on failure
  */
-int set_handler(int sig, int sig_to_mask, int flag)
+static int set_handler(int sig, int sig_to_mask, int flag)
 {
 	struct sigaction sa;
 	int err;

--- a/testcases/kernel/syscalls/sighold/sighold02.c
+++ b/testcases/kernel/syscalls/sighold/sighold02.c
@@ -61,8 +61,8 @@
 # define NUMSIGS NSIG
 #endif
 
-char *TCID = "sighold02";
-int TST_TOTAL = 2;
+static char *TCID = "sighold02";
+static int TST_TOTAL = 2;
 
 static int pid;
 static void do_child(void);
@@ -138,7 +138,7 @@ static void handle_sigs(int sig)
 	sigs_catched++;
 }
 
-void do_child(void)
+static void do_child(void)
 {
 	int cnt;
 	int sig;

--- a/testcases/kernel/syscalls/signal/signal01.c
+++ b/testcases/kernel/syscalls/signal/signal01.c
@@ -72,8 +72,8 @@ static struct tcase {
 	{catchsig, 1},
 };
 
-char *TCID = "signal01";
-int TST_TOTAL = ARRAY_SIZE(tcases);
+static char *TCID = "signal01";
+static int TST_TOTAL = ARRAY_SIZE(tcases);
 
 static int tcase;
 

--- a/testcases/kernel/syscalls/signal/signal06.c
+++ b/testcases/kernel/syscalls/signal/signal06.c
@@ -50,8 +50,8 @@
 #include "test.h"
 #include "lapi/syscalls.h"
 
-char *TCID = "signal06";
-int TST_TOTAL = 5;
+static char *TCID = "signal06";
+static int TST_TOTAL = 5;
 
 #if __x86_64__
 

--- a/testcases/kernel/syscalls/signalfd/signalfd01.c
+++ b/testcases/kernel/syscalls/signalfd/signalfd01.c
@@ -47,7 +47,7 @@
 #include "ltp_signal.h"
 
 TCID_DEFINE(signalfd01);
-int TST_TOTAL = 1;
+static int TST_TOTAL = 1;
 
 #ifndef HAVE_SIGNALFD
 #define  USE_STUB
@@ -82,10 +82,10 @@ int signalfd(int fd, const sigset_t * mask, int flags)
 }
 #endif
 
-void cleanup(void);
-void setup(void);
+static void cleanup(void);
+static void setup(void);
 
-int do_test1(uint32_t sig)
+static int do_test1(uint32_t sig)
 {
 	int sfd_for_next;
 	int sfd;
@@ -177,7 +177,7 @@ out:
 	return sfd_for_next;
 }
 
-void do_test2(int fd, uint32_t sig)
+static void do_test2(int fd, uint32_t sig)
 {
 	int sfd;
 	sigset_t mask;
@@ -291,7 +291,7 @@ int main(int argc, char **argv)
 /*
  * setup() - performs all the ONE TIME setup for this test.
  */
-void setup(void)
+static void setup(void)
 {
 
 	TEST_PAUSE;
@@ -301,7 +301,7 @@ void setup(void)
  * cleanup() - performs all the ONE TIME cleanup for this test at completion
  * 	       or premature exit.
  */
-void cleanup(void)
+static void cleanup(void)
 {
 
 }

--- a/testcases/kernel/syscalls/sigrelse/sigrelse01.c
+++ b/testcases/kernel/syscalls/sigrelse/sigrelse01.c
@@ -120,8 +120,8 @@ extern int sigrelse(int __sig);
 #define SIGCANCEL 32
 #define SIGTIMER 33
 
-void setup(void);
-void cleanup(void);
+static void setup(void);
+static void cleanup(void);
 static void parent(void);
 static void child(void);
 static void timeout(int sig);
@@ -157,9 +157,9 @@ int choose_sig(int sig);
 #define WRITE_BROK 16
 #define HANDLE_ERR 32
 
-int TST_TOTAL = 1;		/* number of test items */
+static int TST_TOTAL = 1;		/* number of test items */
 
-char *TCID = "sigrelse01";	/* test case identifier */
+static char *TCID = "sigrelse01";	/* test case identifier */
 static char mesg[MAXMESG];	/* message buffer for tst_res */
 static int pid;			/* process id of child */
 static int pipe_fd[2];		/* file descriptors for pipe parent read */
@@ -756,7 +756,7 @@ int choose_sig(int sig)
 
 }
 
-void setup(void)
+static void setup(void)
 {
 
 	tst_sig(FORK, DEF_HANDLER, cleanup);
@@ -788,7 +788,7 @@ void setup(void)
 			 "fcntl(Fds[0], F_SETFL, O_NONBLOCK) failed");
 }
 
-void cleanup(void)
+static void cleanup(void)
 {
 	tst_rmdir();
 

--- a/testcases/kernel/syscalls/sigwaitinfo/sigwaitinfo01.c
+++ b/testcases/kernel/syscalls/sigwaitinfo/sigwaitinfo01.c
@@ -484,7 +484,7 @@ const char *TCID = "sigtimedwait01";
 const char *TCID = "sigwait01";
 #endif
 
-int TST_TOTAL = ARRAY_SIZE(tests);
+static int TST_TOTAL = ARRAY_SIZE(tests);
 
 int main(int argc, char **argv)
 {

--- a/testcases/kernel/syscalls/socket/socket01.c
+++ b/testcases/kernel/syscalls/socket/socket01.c
@@ -20,7 +20,7 @@
 #include <netinet/in.h>
 #include "tst_test.h"
 
-struct test_case_t {
+static struct test_case_t {
 	int domain;
 	int type;
 	int proto;

--- a/testcases/kernel/syscalls/socketpair/socketpair01.c
+++ b/testcases/kernel/syscalls/socketpair/socketpair01.c
@@ -21,7 +21,7 @@
 
 static int fds[2];
 
-struct test_case_t {
+static struct test_case_t {
 	int domain;
 	int type;
 	int proto;

--- a/testcases/kernel/syscalls/stat/stat01.c
+++ b/testcases/kernel/syscalls/stat/stat01.c
@@ -22,9 +22,9 @@
 #define NEW_MODE         0222
 #define MASK             0777
 
-uid_t user_id;
-gid_t group_id;
-struct passwd *ltpuser;
+static uid_t user_id;
+static gid_t group_id;
+static struct passwd *ltpuser;
 
 static struct tcase{
 	char *pathname;
@@ -75,7 +75,7 @@ static void verify_stat(unsigned int n)
 		tst_res(TPASS, "stat(%s)", tc->pathname);
 }
 
-void setup(void)
+static void setup(void)
 {
 	unsigned int i;
 

--- a/testcases/kernel/syscalls/stat/stat02.c
+++ b/testcases/kernel/syscalls/stat/stat02.c
@@ -35,7 +35,7 @@ static struct test_case {
 	{ FNAME2, BUFSIZE, 1000 }
 };
 
-void verify(const char *fname, size_t bytes, size_t decrement)
+static void verify(const char *fname, size_t bytes, size_t decrement)
 {
 	struct stat s;
 	int fd, i;
@@ -67,19 +67,19 @@ void verify(const char *fname, size_t bytes, size_t decrement)
 	tst_res(TPASS, "File size reported as expected");
 }
 
-void verify_stat_size(unsigned int nr)
+static void verify_stat_size(unsigned int nr)
 {
 	struct test_case *tcase = &tcases[nr];
 
 	verify(tcase->filename, tcase->bytes_to_write, tcase->decrement);
 }
 
-void setup(void)
+static void setup(void)
 {
 	buffer = SAFE_MALLOC(BUFSIZE);
 }
 
-void cleanup(void)
+static void cleanup(void)
 {
 	free(buffer);
 }

--- a/testcases/kernel/syscalls/stat/stat03.c
+++ b/testcases/kernel/syscalls/stat/stat03.c
@@ -23,7 +23,7 @@
 #define MODE_RW	        0666
 #define DIR_MODE        0755
 
-struct passwd *ltpuser;
+static struct passwd *ltpuser;
 
 static char long_dir[PATH_MAX + 2] = {[0 ... PATH_MAX + 1] = 'a'};
 static char loop_dir[PATH_MAX] = ".";

--- a/testcases/kernel/syscalls/statfs/statfs01.c
+++ b/testcases/kernel/syscalls/statfs/statfs01.c
@@ -117,15 +117,15 @@
 #include <string.h>
 #include "test.h"
 
-void setup();
-void cleanup();
+static void setup();
+static void cleanup();
 
-char *TCID = "statfs01";
-int TST_TOTAL = 1;
+static char *TCID = "statfs01";
+static int TST_TOTAL = 1;
 
-char fname[255];
-int fd;
-struct statfs stats;
+static char fname[255];
+static int fd;
+static struct statfs stats;
 
 int main(int ac, char **av)
 {
@@ -161,7 +161,7 @@ int main(int ac, char **av)
 /***************************************************************
  * setup() - performs all ONE TIME setup for this test.
  ***************************************************************/
-void setup(void)
+static void setup(void)
 {
 
 	tst_sig(NOFORK, DEF_HANDLER, cleanup);
@@ -190,7 +190,7 @@ void setup(void)
  * cleanup() - performs all ONE TIME cleanup for this test at
  *		completion or premature exit.
  ***************************************************************/
-void cleanup(void)
+static void cleanup(void)
 {
 
 	tst_rmdir();

--- a/testcases/kernel/syscalls/statfs/statfs02.c
+++ b/testcases/kernel/syscalls/statfs/statfs02.c
@@ -42,7 +42,7 @@
 #include "test.h"
 #include "safe_macros.h"
 
-char *TCID = "statfs02";
+static char *TCID = "statfs02";
 
 static int fd;
 
@@ -69,7 +69,7 @@ static struct test_case_t {
 	{TEST_SYMLINK, &buf, ELOOP},
 };
 
-int TST_TOTAL = ARRAY_SIZE(TC);
+static int TST_TOTAL = ARRAY_SIZE(TC);
 static void setup(void);
 static void cleanup(void);
 static void statfs_verify(const struct test_case_t *);

--- a/testcases/kernel/syscalls/statvfs/statvfs01.c
+++ b/testcases/kernel/syscalls/statvfs/statvfs01.c
@@ -35,8 +35,8 @@
 static void setup(void);
 static void cleanup(void);
 
-char *TCID = "statvfs01";
-int TST_TOTAL = 1;
+static char *TCID = "statvfs01";
+static int TST_TOTAL = 1;
 
 int main(int ac, char **av)
 {

--- a/testcases/kernel/syscalls/statvfs/statvfs02.c
+++ b/testcases/kernel/syscalls/statvfs/statvfs02.c
@@ -36,7 +36,7 @@
 #define TEST_SYMLINK	"statvfs_symlink"
 #define TEST_FILE	"statvfs_file"
 
-char *TCID = "statvfs02";
+static char *TCID = "statvfs02";
 
 static struct statvfs buf;
 static char nametoolong[PATH_MAX+2];
@@ -55,7 +55,7 @@ static struct test_case_t {
 	{"statvfs_file/test", &buf, ENOTDIR},
 };
 
-int TST_TOTAL = ARRAY_SIZE(test_cases);
+static int TST_TOTAL = ARRAY_SIZE(test_cases);
 static void statvfs_verify(const struct test_case_t *);
 
 int main(int argc, char **argv)

--- a/testcases/kernel/syscalls/statx/statx01.c
+++ b/testcases/kernel/syscalls/statx/statx01.c
@@ -131,7 +131,7 @@ static void test_device_file(void)
 }
 
 
-struct tcase {
+static struct tcase {
 	void (*tfunc)(void);
 } tcases[] = {
 	{&test_normal_file},

--- a/testcases/kernel/syscalls/statx/statx04.c
+++ b/testcases/kernel/syscalls/statx/statx04.c
@@ -103,7 +103,7 @@ static void test_unflagged(void)
 		tst_res(TFAIL, "STATX_ATTR_NODUMP flag is set");
 }
 
-struct test_cases {
+static struct test_cases {
 	void (*tfunc)(void);
 } tcases[] = {
 	{&test_flagged},

--- a/testcases/kernel/syscalls/statx/statx05.c
+++ b/testcases/kernel/syscalls/statx/statx05.c
@@ -72,7 +72,7 @@ static void test_unflagged(void)
 		tst_res(TFAIL, "STATX_ATTR_ENCRYPTED flag is set");
 }
 
-struct test_cases {
+static struct test_cases {
 	void (*tfunc)(void);
 } tcases[] = {
 	{&test_flagged},

--- a/testcases/kernel/syscalls/statx/statx07.c
+++ b/testcases/kernel/syscalls/statx/statx07.c
@@ -45,6 +45,7 @@
 #include <errno.h>
 #include <linux/limits.h>
 #include <sys/mount.h>
+#include <sys/wait.h>
 #include "tst_test.h"
 #include "lapi/stat.h"
 
@@ -84,7 +85,7 @@ static int get_mode(char *file_name, int flag_type, char *flag_name)
 	return buf.stx_mode;
 }
 
-const struct test_cases {
+static const struct test_cases {
 	int flag;
 	char *flag_name;
 	char *server_file;

--- a/testcases/kernel/syscalls/string/string01.c
+++ b/testcases/kernel/syscalls/string/string01.c
@@ -46,12 +46,12 @@
 #define FAILED 0
 #define PASSED 1
 
-char *TCID = "string01";
+static char *TCID = "string01";
 
-int local_flag = PASSED;
-int block_number;
-FILE *temp;
-int TST_TOTAL = 1;
+static int local_flag = PASSED;
+static int block_number;
+static FILE *temp;
+static int TST_TOTAL = 1;
 /*****	**	** *****/
 
 #define LONGSTR	(96*1024-1)
@@ -232,23 +232,23 @@ struct t_strncpy {
 	NULL, NULL, 0, NULL, 0}
 };
 
-void setup();
-int blenter();
-int blexit();
-int anyfail();
+static void setup();
+static int blenter();
+static int blexit();
+static int anyfail();
 
-void setup(void)
+static void setup(void)
 {
 	temp = stderr;
 }
 
-int blenter(void)
+static int blenter(void)
 {
 	local_flag = PASSED;
 	return 0;
 }
 
-int blexit(void)
+static int blexit(void)
 {
 	(local_flag == PASSED) ? tst_resm(TPASS,
 					  "Test passed") : tst_resm(TFAIL,
@@ -256,7 +256,7 @@ int blexit(void)
 	return 0;
 }
 
-int anyfail(void)
+static int anyfail(void)
 {
 	tst_exit();
 }

--- a/testcases/kernel/syscalls/symlink/symlink01.c
+++ b/testcases/kernel/syscalls/symlink/symlink01.c
@@ -218,10 +218,10 @@
 
 #include "test.h"
 
-void setup(void);
-void cleanup(void);
-void help(void);
-void delete_files(char *path1, char *path2);
+static void setup(void);
+static void cleanup(void);
+static void help(void);
+static void delete_files(char *path1, char *path2);
 struct all_test_cases;
 void do_EEXIST(struct all_test_cases *tc_ptr);
 void do_ENOENT(struct all_test_cases *tc_ptr);
@@ -230,15 +230,15 @@ void do_ENOTDIR(struct all_test_cases *tc_ptr);
 void do_EXDEV(struct all_test_cases *tc_ptr);
 void do_ENAMETOOLONG(struct all_test_cases *tc_ptr);
 void do_EINVAL(struct all_test_cases *tc_ptr);
-void do_readlink(struct all_test_cases *tc_ptr);
-void do_stat(struct all_test_cases *tc_ptr);
-void do_chdir(struct all_test_cases *tc_ptr);
-void do_link(struct all_test_cases *tc_ptr);
-void do_unlink(struct all_test_cases *tc_ptr);
-void do_chmod(struct all_test_cases *tc_ptr);
-void do_utime(struct all_test_cases *tc_ptr);
-void do_rename(struct all_test_cases *tc_ptr);
-void do_open(struct all_test_cases *tc_ptr);
+static void do_readlink(struct all_test_cases *tc_ptr);
+static void do_stat(struct all_test_cases *tc_ptr);
+static void do_chdir(struct all_test_cases *tc_ptr);
+static void do_link(struct all_test_cases *tc_ptr);
+static void do_unlink(struct all_test_cases *tc_ptr);
+static void do_chmod(struct all_test_cases *tc_ptr);
+static void do_utime(struct all_test_cases *tc_ptr);
+static void do_rename(struct all_test_cases *tc_ptr);
+static void do_open(struct all_test_cases *tc_ptr);
 struct tcses;
 int do_syscalltests(struct tcses *tcs);
 struct tcses *get_tcs_info(char *ptr);
@@ -325,7 +325,7 @@ int ck_path_max(char *path1, char *path2, char *path3);
 /*
  *  Define test cases
  */
-struct all_test_cases {
+static struct all_test_cases {
 	char *tcid;
 	int test_fail;
 	int errno_val;
@@ -493,21 +493,21 @@ OPEN, "open", 5, &test_objects[39],
  * Define GLOBAL variables
  */
 
-int TST_TOTAL;
-int TEST_RESULT;
-time_t a_time_value = 100;
-char *TCID;
-char *Selectedtests = NULL;	/* Name (tcid) of selected test cases */
-char test_msg[BUFMAX];
-char full_path[PATH_MAX + 1 + 1];	/* Add one for '\0' and another to exceed the PATH_MAX limit, see creat_path_max() */
+static int TST_TOTAL;
+static int TEST_RESULT;
+static time_t a_time_value = 100;
+static char *TCID;
+static char *Selectedtests = NULL;	/* Name (tcid) of selected test cases */
+static char test_msg[BUFMAX];
+static char full_path[PATH_MAX + 1 + 1];	/* Add one for '\0' and another to exceed the PATH_MAX limit, see creat_path_max() */
 
-struct stat asymlink, statter;
-char Buffer[1024];
-char Buf[1024];
+static struct stat asymlink, statter;
+static char Buffer[1024];
+static char Buf[1024];
 
-char *Tcid = NULL;
+static char *Tcid = NULL;
 
-option_t Options[] = {
+static option_t Options[] = {
 	{"T:", NULL, &Tcid},	/* -T tcid option */
 	{NULL, NULL, NULL}
 };
@@ -1379,7 +1379,7 @@ void do_EINVAL(struct all_test_cases *tc_ptr)
  *   Argument is pointer to test_objects array of structures of type
  *   all_test_cases
  ***********************************************************************/
-void do_readlink(struct all_test_cases *tc_ptr)
+static void do_readlink(struct all_test_cases *tc_ptr)
 {
 	char scratch[PATH_MAX];
 	int ret;
@@ -1415,7 +1415,7 @@ void do_readlink(struct all_test_cases *tc_ptr)
  *   Argument is pointer to test_objects array of structures of type
  *   all_test_cases
  ***********************************************************************/
-void do_stat(struct all_test_cases *tc_ptr)
+static void do_stat(struct all_test_cases *tc_ptr)
 {
 	if (statter.st_dev != asymlink.st_dev)
 		tst_resm(TFAIL,
@@ -1474,7 +1474,7 @@ void do_stat(struct all_test_cases *tc_ptr)
  *   Argument is pointer to test_objects array of structures of type
  *   all_test_cases
  ***********************************************************************/
-void do_chdir(struct all_test_cases *tc_ptr)
+static void do_chdir(struct all_test_cases *tc_ptr)
 {
 	if (mkdir(tc_ptr->fn_arg[2], MODE) == -1)
 		tst_resm(TFAIL, "Could not create a setup directory file");
@@ -1527,7 +1527,7 @@ void do_chdir(struct all_test_cases *tc_ptr)
  *   Argument is pointer to test_objects array of structures of type
  *   all_test_cases
  ***********************************************************************/
-void do_link(struct all_test_cases *tc_ptr)
+static void do_link(struct all_test_cases *tc_ptr)
 {
 	struct stat stbuf;
 
@@ -1584,7 +1584,7 @@ void do_link(struct all_test_cases *tc_ptr)
  *   Argument is pointer to test_objects array of structures of type
  *   all_test_cases
  ***********************************************************************/
-void do_unlink(struct all_test_cases *tc_ptr)
+static void do_unlink(struct all_test_cases *tc_ptr)
 {
 	if (stat(tc_ptr->fn_arg[2], &asymlink) == -1)
 		tst_resm(TBROK, "stat(2) Failure when accessing %s object file",
@@ -1622,7 +1622,7 @@ void do_unlink(struct all_test_cases *tc_ptr)
  *   Argument is pointer to test_objects array of structures of type
  *   all_test_cases
  ***********************************************************************/
-void do_chmod(struct all_test_cases *tc_ptr)
+static void do_chmod(struct all_test_cases *tc_ptr)
 {
 	if (stat(tc_ptr->fn_arg[2], &asymlink) == -1)
 		tst_resm(TBROK, "stat(2) Failure when accessing %s object file",
@@ -1660,7 +1660,7 @@ void do_chmod(struct all_test_cases *tc_ptr)
  *   Argument is pointer to test_objects array of structures of type
  *   all_test_cases
  ***********************************************************************/
-void do_utime(struct all_test_cases *tc_ptr)
+static void do_utime(struct all_test_cases *tc_ptr)
 {
 	struct utimbuf utimes;
 
@@ -1716,7 +1716,7 @@ void do_utime(struct all_test_cases *tc_ptr)
  *   Argument is pointer to test_objects array of structures of type
  *   all_test_cases
  ***********************************************************************/
-void do_rename(struct all_test_cases *tc_ptr)
+static void do_rename(struct all_test_cases *tc_ptr)
 {
 	int pts_at_object = 0;
 
@@ -1753,7 +1753,7 @@ void do_rename(struct all_test_cases *tc_ptr)
  *   Argument is pointer to test_objects array of structures of type
  *   all_test_cases
  ***********************************************************************/
-void do_open(struct all_test_cases *tc_ptr)
+static void do_open(struct all_test_cases *tc_ptr)
 {
 	int fd = -1;
 	int ret, pts_at_object = 0;
@@ -1850,7 +1850,7 @@ void do_open(struct all_test_cases *tc_ptr)
 /***************************************************************
  * setup() - performs all ONE TIME setup for this test.
  ***************************************************************/
-void setup(void)
+static void setup(void)
 {
 
 	tst_sig(FORK, DEF_HANDLER, cleanup);
@@ -1866,14 +1866,14 @@ void setup(void)
  * cleanup() - performs all ONE TIME cleanup for this test at
  *              completion or premature exit.
  ***************************************************************/
-void cleanup(void)
+static void cleanup(void)
 {
 
 	tst_rmdir();
 
 }
 
-void help(void)
+static void help(void)
 {
 	int ind;
 

--- a/testcases/kernel/syscalls/symlink/symlink02.c
+++ b/testcases/kernel/syscalls/symlink/symlink02.c
@@ -117,14 +117,14 @@
 #include "test.h"
 #include "safe_macros.h"
 
-void setup();
-void cleanup();
+static void setup();
+static void cleanup();
 
-char *TCID = "symlink02";
-int TST_TOTAL = 1;
+static char *TCID = "symlink02";
+static int TST_TOTAL = 1;
 
-char fname[255], symlnk[255];
-int fd;
+static char fname[255], symlnk[255];
+static int fd;
 
 int main(int ac, char **av)
 {
@@ -173,7 +173,7 @@ int main(int ac, char **av)
 /***************************************************************
  * setup() - performs all ONE TIME setup for this test.
  ***************************************************************/
-void setup(void)
+static void setup(void)
 {
 
 	tst_sig(NOFORK, DEF_HANDLER, cleanup);
@@ -200,7 +200,7 @@ void setup(void)
  * cleanup() - performs all ONE TIME cleanup for this test at
  *		completion or premature exit.
  ***************************************************************/
-void cleanup(void)
+static void cleanup(void)
 {
 
 	tst_rmdir();

--- a/testcases/kernel/syscalls/symlinkat/symlinkat01.c
+++ b/testcases/kernel/syscalls/symlinkat/symlinkat01.c
@@ -67,7 +67,7 @@ static char dpathname[256] = "%s/" TEST_DIR2 "/" TEST_FILE1;
 static int olddirfd, newdirfd = -1, cwd_fd = AT_FDCWD, stdinfd = 0, crapfd =
     -1, deldirfd;
 
-struct test_struct {
+static struct test_struct {
 	const char *oldfn;
 	int *newfd;
 	const char *newfn;
@@ -120,8 +120,8 @@ struct test_struct {
 	    /*      { TEST_FIFO, &newdirfd, TEST_FILE1, TEST_DIR1"/"TEST_FIFO, TEST_DIR2"/"TEST_FILE1, 0 }, */
 };
 
-char *TCID = "symlinkat01";
-int TST_TOTAL = sizeof(test_desc) / sizeof(*test_desc);
+static char *TCID = "symlinkat01";
+static int TST_TOTAL = sizeof(test_desc) / sizeof(*test_desc);
 
 static int mysymlinkat(const char *oldfilename,
 		       int newdirfd, const char *newfilename)

--- a/testcases/kernel/syscalls/sync/sync01.c
+++ b/testcases/kernel/syscalls/sync/sync01.c
@@ -114,11 +114,11 @@
 #include <signal.h>
 #include "test.h"
 
-void setup();
-void cleanup();
+static void setup();
+static void cleanup();
 
-char *TCID = "sync01";
-int TST_TOTAL = 1;
+static char *TCID = "sync01";
+static int TST_TOTAL = 1;
 
 int main(int ac, char **av)
 {
@@ -163,7 +163,7 @@ int main(int ac, char **av)
 /***************************************************************
  * setup() - performs all ONE TIME setup for this test.
  ***************************************************************/
-void setup(void)
+static void setup(void)
 {
 
 	tst_sig(NOFORK, DEF_HANDLER, cleanup);
@@ -176,7 +176,7 @@ void setup(void)
  * cleanup() - performs all ONE TIME cleanup for this test at
  *		completion or premature exit.
  ***************************************************************/
-void cleanup(void)
+static void cleanup(void)
 {
 
 }

--- a/testcases/kernel/syscalls/sync/sync02.c
+++ b/testcases/kernel/syscalls/sync/sync02.c
@@ -80,13 +80,13 @@
 #define TEMP_FILE	"temp_file"
 #define FILE_MODE       S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH
 
-char *TCID = "sync02";
-int TST_TOTAL = 1;
-char write_buffer[BUFSIZ];	/* buffer used to write data to file */
-int fildes;			/* file descriptor for temporary file */
+static char *TCID = "sync02";
+static int TST_TOTAL = 1;
+static char write_buffer[BUFSIZ];	/* buffer used to write data to file */
+static int fildes;			/* file descriptor for temporary file */
 
-void setup();			/* Main setup function of test */
-void cleanup();			/* cleanup function for the test */
+static void setup();			/* Main setup function of test */
+static void cleanup();			/* cleanup function for the test */
 
 int main(int ac, char **av)
 {
@@ -149,7 +149,7 @@ int main(int ac, char **av)
  *  Create a test file under temporary directory and write some
  *  data into it.
  */
-void setup(void)
+static void setup(void)
 {
 
 	tst_sig(NOFORK, DEF_HANDLER, cleanup);
@@ -189,7 +189,7 @@ void setup(void)
  *             completion or premature exit.
  *  Remove the test directory and testfile created in the setup.
  */
-void cleanup(void)
+static void cleanup(void)
 {
 
 	/* Close the temporary file */

--- a/testcases/kernel/syscalls/sysinfo/sysinfo01.c
+++ b/testcases/kernel/syscalls/sysinfo/sysinfo01.c
@@ -73,11 +73,11 @@
 
 #include "test.h"
 
-void setup();
-void cleanup();
+static void setup();
+static void cleanup();
 
-char *TCID = "sysinfo01";
-int TST_TOTAL = 1;
+static char *TCID = "sysinfo01";
+static int TST_TOTAL = 1;
 
 int main(int ac, char **av)
 {
@@ -157,7 +157,7 @@ int main(int ac, char **av)
  *	performs one time setup
  *
  */
-void setup(void)
+static void setup(void)
 {
 
 	tst_sig(FORK, DEF_HANDLER, cleanup);
@@ -171,6 +171,6 @@ void setup(void)
  * cleanup()
  *
  */
-void cleanup(void)
+static void cleanup(void)
 {
 }

--- a/testcases/kernel/syscalls/sysinfo/sysinfo02.c
+++ b/testcases/kernel/syscalls/sysinfo/sysinfo02.c
@@ -72,11 +72,11 @@
 
 #define INVALID_ADDRESS ((uintptr_t)-1)
 
-void setup();
-void cleanup();
+static void setup();
+static void cleanup();
 
-char *TCID = "sysinfo02";
-int TST_TOTAL = 1;
+static char *TCID = "sysinfo02";
+static int TST_TOTAL = 1;
 
 #if !defined(UCLINUX)
 
@@ -130,7 +130,7 @@ int main(void)
  *	performs one time setup
  *
  */
-void setup(void)
+static void setup(void)
 {
 
 	tst_sig(FORK, DEF_HANDLER, cleanup);
@@ -144,6 +144,6 @@ void setup(void)
  * cleanup()
  *
  */
-void cleanup(void)
+static void cleanup(void)
 {
 }

--- a/testcases/kernel/syscalls/syslog/syslogtst.c
+++ b/testcases/kernel/syscalls/syslog/syslogtst.c
@@ -30,10 +30,10 @@
 #include <unistd.h>
 #include "test.h"
 
-char *TCID = "syslogtst";
-int TST_TOTAL = 1;
+static char *TCID = "syslogtst";
+static int TST_TOTAL = 1;
 
-void sig_handler(int signal);
+static void sig_handler(int signal);
 
 int main(int argc, char *argv[])
 {
@@ -301,7 +301,7 @@ int main(int argc, char *argv[])
 
 }
 
-void sig_handler(int signal)
+static void sig_handler(int signal)
 {
 
 	switch (signal) {

--- a/testcases/kernel/syscalls/time/time01.c
+++ b/testcases/kernel/syscalls/time/time01.c
@@ -115,11 +115,11 @@
 #include <time.h>
 #include "test.h"
 
-void setup();
-void cleanup();
+static void setup();
+static void cleanup();
 
-char *TCID = "time01";
-int TST_TOTAL = 1;
+static char *TCID = "time01";
+static int TST_TOTAL = 1;
 
 int main(int ac, char **av)
 {
@@ -155,7 +155,7 @@ int main(int ac, char **av)
 /***************************************************************
  * setup() - performs all ONE TIME setup for this test.
  ***************************************************************/
-void setup(void)
+static void setup(void)
 {
 	void trapper();
 
@@ -168,6 +168,6 @@ void setup(void)
  * cleanup() - performs all ONE TIME cleanup for this test at
  *		completion or premature exit.
  ***************************************************************/
-void cleanup(void)
+static void cleanup(void)
 {
 }

--- a/testcases/kernel/syscalls/timer_getoverrun/timer_getoverrun01.c
+++ b/testcases/kernel/syscalls/timer_getoverrun/timer_getoverrun01.c
@@ -29,8 +29,8 @@
 #include "test.h"
 #include "lapi/syscalls.h"
 
-char *TCID = "timer_getoverrun01";
-int TST_TOTAL = 1;
+static char *TCID = "timer_getoverrun01";
+static int TST_TOTAL = 1;
 
 static void cleanup(void)
 {

--- a/testcases/kernel/syscalls/timer_gettime/timer_gettime01.c
+++ b/testcases/kernel/syscalls/timer_gettime/timer_gettime01.c
@@ -29,8 +29,8 @@
 #include "test.h"
 #include "lapi/syscalls.h"
 
-char *TCID = "timer_gettime01";
-int TST_TOTAL = 3;
+static char *TCID = "timer_gettime01";
+static int TST_TOTAL = 3;
 
 static void cleanup(void)
 {

--- a/testcases/kernel/syscalls/timerfd/timerfd_create01.c
+++ b/testcases/kernel/syscalls/timerfd/timerfd_create01.c
@@ -29,7 +29,7 @@
 #include "test.h"
 #include "lapi/timerfd.h"
 
-char *TCID = "timerfd_create01";
+static char *TCID = "timerfd_create01";
 
 static struct test_case_t {
 	int clockid;
@@ -40,7 +40,7 @@ static struct test_case_t {
 	{0, -1, EINVAL},
 };
 
-int TST_TOTAL = ARRAY_SIZE(test_cases);
+static int TST_TOTAL = ARRAY_SIZE(test_cases);
 static void setup(void);
 static void timerfd_create_verify(const struct test_case_t *);
 static void cleanup(void);

--- a/testcases/kernel/syscalls/timerfd/timerfd_gettime01.c
+++ b/testcases/kernel/syscalls/timerfd/timerfd_gettime01.c
@@ -33,7 +33,7 @@
 #include "safe_macros.h"
 #include "lapi/timerfd.h"
 
-char *TCID = "timerfd_gettime01";
+static char *TCID = "timerfd_gettime01";
 
 static int bad_clockfd = -1;
 static int clockfd;
@@ -49,7 +49,7 @@ static struct test_case_t {
 	{&fd, NULL, EINVAL},
 };
 
-int TST_TOTAL = ARRAY_SIZE(test_cases);
+static int TST_TOTAL = ARRAY_SIZE(test_cases);
 static void setup(void);
 static void timerfd_gettime_verify(const struct test_case_t *);
 static void cleanup(void);

--- a/testcases/kernel/syscalls/timerfd/timerfd_settime01.c
+++ b/testcases/kernel/syscalls/timerfd/timerfd_settime01.c
@@ -34,7 +34,7 @@
 #include "safe_macros.h"
 #include "lapi/timerfd.h"
 
-char *TCID = "timerfd_settime01";
+static char *TCID = "timerfd_settime01";
 
 static int bad_clockfd = -1;
 static int clockfd;
@@ -52,7 +52,7 @@ static struct test_case_t {
 	{&clockfd, -1, NULL, EINVAL},
 };
 
-int TST_TOTAL = ARRAY_SIZE(test_cases);
+static int TST_TOTAL = ARRAY_SIZE(test_cases);
 static void setup(void);
 static void timerfd_settime_verify(const struct test_case_t *);
 static void cleanup(void);

--- a/testcases/kernel/syscalls/times/times01.c
+++ b/testcases/kernel/syscalls/times/times01.c
@@ -116,11 +116,11 @@
 #include <signal.h>
 #include "test.h"
 
-void setup();
-void cleanup();
+static void setup();
+static void cleanup();
 
-char *TCID = "times01";
-int TST_TOTAL = 1;
+static char *TCID = "times01";
+static int TST_TOTAL = 1;
 
 struct tms mytimes;
 
@@ -150,13 +150,13 @@ int main(int ac, char **av)
 	tst_exit();
 }
 
-void setup(void)
+static void setup(void)
 {
 	tst_sig(NOFORK, DEF_HANDLER, cleanup);
 
 	TEST_PAUSE;
 }
 
-void cleanup(void)
+static void cleanup(void)
 {
 }

--- a/testcases/kernel/syscalls/tkill/tkill02.c
+++ b/testcases/kernel/syscalls/tkill/tkill02.c
@@ -35,18 +35,18 @@
 #include "test.h"
 #include "lapi/syscalls.h"
 
-char *TCID = "tkill02";
-int testno;
+static char *TCID = "tkill02";
+static int testno;
 
 static pid_t inval_tid = -1;
 static pid_t unused_tid;
 
-void cleanup(void)
+static void cleanup(void)
 {
 	tst_rmdir();
 }
 
-void setup(void)
+static void setup(void)
 {
 	TEST_PAUSE;
 	tst_tmpdir();
@@ -54,7 +54,7 @@ void setup(void)
 	unused_tid = tst_get_unused_pid(cleanup);
 }
 
-struct test_case_t {
+static struct test_case_t {
 	int *tid;
 	int exp_errno;
 } test_cases[] = {
@@ -62,7 +62,7 @@ struct test_case_t {
 	{&unused_tid, ESRCH}
 };
 
-int TST_TOTAL = sizeof(test_cases) / sizeof(test_cases[0]);
+static int TST_TOTAL = sizeof(test_cases) / sizeof(test_cases[0]);
 
 int main(int ac, char **av)
 {

--- a/testcases/kernel/syscalls/truncate/truncate03.c
+++ b/testcases/kernel/syscalls/truncate/truncate03.c
@@ -88,8 +88,8 @@ static void setup(void);
 static void cleanup(void);
 static void truncate_verify(struct test_case_t *);
 
-char *TCID = "truncate03";
-int TST_TOTAL = ARRAY_SIZE(test_cases);
+static char *TCID = "truncate03";
+static int TST_TOTAL = ARRAY_SIZE(test_cases);
 
 int main(int ac, char **av)
 {

--- a/testcases/kernel/syscalls/umount2/umount2_01.c
+++ b/testcases/kernel/syscalls/umount2/umount2_01.c
@@ -33,8 +33,8 @@ static void setup(void);
 static void umount2_verify(void);
 static void cleanup(void);
 
-char *TCID = "umount2_01";
-int TST_TOTAL = 1;
+static char *TCID = "umount2_01";
+static int TST_TOTAL = 1;
 
 #define DIR_MODE	(S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH)
 #define FILE_MODE	(S_IRWXU | S_IRWXG | S_IRWXO | S_ISUID | S_ISGID)

--- a/testcases/kernel/syscalls/umount2/umount2_02.c
+++ b/testcases/kernel/syscalls/umount2/umount2_02.c
@@ -67,8 +67,8 @@ static struct test_case_t {
 		"second call to umount2(2) with MNT_EXPIRE expected success"},
 };
 
-char *TCID = "umount2_02";
-int TST_TOTAL = ARRAY_SIZE(test_cases);
+static char *TCID = "umount2_02";
+static int TST_TOTAL = ARRAY_SIZE(test_cases);
 
 int main(int ac, char **av)
 {

--- a/testcases/kernel/syscalls/umount2/umount2_03.c
+++ b/testcases/kernel/syscalls/umount2/umount2_03.c
@@ -56,8 +56,8 @@ static struct test_case_t {
 		"umount2('mntpoint', UMOUNT_NOFOLLOW) expected success"},
 };
 
-char *TCID = "umount2_03";
-int TST_TOTAL = ARRAY_SIZE(test_cases);
+static char *TCID = "umount2_03";
+static int TST_TOTAL = ARRAY_SIZE(test_cases);
 
 int main(int ac, char **av)
 {

--- a/testcases/kernel/syscalls/uname/uname01.c
+++ b/testcases/kernel/syscalls/uname/uname01.c
@@ -115,11 +115,11 @@
 #include <signal.h>
 #include "test.h"
 
-void setup();
-void cleanup();
+static void setup();
+static void cleanup();
 
-char *TCID = "uname01";
-int TST_TOTAL = 1;
+static char *TCID = "uname01";
+static int TST_TOTAL = 1;
 
 struct utsname un;
 
@@ -148,7 +148,7 @@ int main(int ac, char **av)
 	tst_exit();
 }
 
-void setup(void)
+static void setup(void)
 {
 	void trapper();
 
@@ -157,6 +157,6 @@ void setup(void)
 	TEST_PAUSE;
 }
 
-void cleanup(void)
+static void cleanup(void)
 {
 }

--- a/testcases/kernel/syscalls/uname/uname03.c
+++ b/testcases/kernel/syscalls/uname/uname03.c
@@ -57,11 +57,11 @@
 #include <sys/utsname.h>
 #include <string.h>
 
-void cleanup(void);
-void setup(void);
+static void cleanup(void);
+static void setup(void);
 
-char *TCID = "uname03";
-int TST_TOTAL = 1;
+static char *TCID = "uname03";
+static int TST_TOTAL = 1;
 
 #define LINUX	"Linux"
 
@@ -114,7 +114,7 @@ int main(int ac, char **av)
 /*
  * setup() - performs all the ONE TIME setup for this test.
  */
-void setup(void)
+static void setup(void)
 {
 
 	tst_sig(FORK, DEF_HANDLER, cleanup);
@@ -126,7 +126,7 @@ void setup(void)
  * cleanup() - performs all the ONE TIME cleanup for this test at completion
  * 	       or premature exit.
  */
-void cleanup(void)
+static void cleanup(void)
 {
 
 }

--- a/testcases/kernel/syscalls/unlinkat/unlinkat01.c
+++ b/testcases/kernel/syscalls/unlinkat/unlinkat01.c
@@ -45,11 +45,11 @@
 #define AT_REMOVEDIR 0x200
 #endif
 
-void setup();
-void cleanup();
+static void setup();
+static void cleanup();
 
-char *TCID = "unlinkat01";
-int TST_TOTAL = TEST_CASES;
+static char *TCID = "unlinkat01";
+static int TST_TOTAL = TEST_CASES;
 
 static const char pathname[] = "unlinkattestdir",
 		  subpathname[] = "unlinkatsubtestdir",
@@ -100,7 +100,7 @@ int main(int ac, char **av)
 	tst_exit();
 }
 
-void setup(void)
+static void setup(void)
 {
 	tst_sig(NOFORK, DEF_HANDLER, cleanup);
 
@@ -134,7 +134,7 @@ void setup(void)
 	TEST_PAUSE;
 }
 
-void cleanup(void)
+static void cleanup(void)
 {
 	if (fds[0] > 0)
 		close(fds[0]);

--- a/testcases/kernel/syscalls/utils/common_j_h.c
+++ b/testcases/kernel/syscalls/utils/common_j_h.c
@@ -116,7 +116,7 @@ static void sigterm_handler(int sig)
 /*
  * Generate a child process which will send a signal
  */
-pid_t create_sig_proc(unsigned long usec, int sig, unsigned count)
+static pid_t create_sig_proc(unsigned long usec, int sig, unsigned count)
 {
 	pid_t pid, cpid;
 

--- a/testcases/kernel/syscalls/utils/compat_16.h
+++ b/testcases/kernel/syscalls/utils/compat_16.h
@@ -72,96 +72,96 @@ if (!GID_SIZE_CHECK(gid)) { \
 }
 
 
-int SETGROUPS(void (cleanup)(void), size_t gidsetsize, GID_T *list)
+static int SETGROUPS(void (cleanup)(void), size_t gidsetsize, GID_T *list)
 {
 	LTP_CREATE_SYSCALL(setgroups, cleanup, gidsetsize, list);
 }
 
-int GETGROUPS(void (cleanup)(void), size_t gidsetsize, GID_T *list)
+static int GETGROUPS(void (cleanup)(void), size_t gidsetsize, GID_T *list)
 {
 	LTP_CREATE_SYSCALL(getgroups, cleanup, gidsetsize, list);
 }
 
-int SETUID(void (cleanup)(void), UID_T uid)
+static int SETUID(void (cleanup)(void), UID_T uid)
 {
 	LTP_CREATE_SYSCALL(setuid, cleanup, uid);
 }
 
-UID_T GETUID(void (cleanup)(void))
+static UID_T GETUID(void (cleanup)(void))
 {
 	LTP_CREATE_SYSCALL(getuid, cleanup);
 }
 
-int SETGID(void (cleanup)(void), GID_T gid)
+static int SETGID(void (cleanup)(void), GID_T gid)
 {
 	LTP_CREATE_SYSCALL(setgid, cleanup, gid);
 }
 
-GID_T GETGID(void (cleanup)(void))
+static GID_T GETGID(void (cleanup)(void))
 {
 	LTP_CREATE_SYSCALL(getgid, cleanup);
 }
 
-UID_T GETEUID(void (cleanup)(void))
+static UID_T GETEUID(void (cleanup)(void))
 {
 	LTP_CREATE_SYSCALL(geteuid, cleanup);
 }
 
-GID_T GETEGID(void (cleanup)(void))
+static GID_T GETEGID(void (cleanup)(void))
 {
 	LTP_CREATE_SYSCALL(getegid, cleanup);
 }
 
-int SETFSUID(void (cleanup)(void), UID_T uid)
+static int SETFSUID(void (cleanup)(void), UID_T uid)
 {
 	LTP_CREATE_SYSCALL(setfsuid, cleanup, uid);
 }
 
-int SETFSGID(void (cleanup)(void), GID_T gid)
+static int SETFSGID(void (cleanup)(void), GID_T gid)
 {
 	LTP_CREATE_SYSCALL(setfsgid, cleanup, gid);
 }
 
-int SETREUID(void (cleanup)(void), UID_T ruid, UID_T euid)
+static int SETREUID(void (cleanup)(void), UID_T ruid, UID_T euid)
 {
 	LTP_CREATE_SYSCALL(setreuid, cleanup, ruid, euid);
 }
-int SETREGID(void (cleanup)(void), GID_T rgid, GID_T egid)
+static int SETREGID(void (cleanup)(void), GID_T rgid, GID_T egid)
 {
 	LTP_CREATE_SYSCALL(setregid, cleanup, rgid, egid);
 }
 
-int SETRESUID(void (cleanup)(void), UID_T ruid, UID_T euid, UID_T suid)
+static int SETRESUID(void (cleanup)(void), UID_T ruid, UID_T euid, UID_T suid)
 {
 	LTP_CREATE_SYSCALL(setresuid, cleanup, ruid, euid, suid);
 }
 
-int GETRESUID(void (cleanup)(void), UID_T *ruid, UID_T *euid, UID_T *suid)
+static int GETRESUID(void (cleanup)(void), UID_T *ruid, UID_T *euid, UID_T *suid)
 {
 	LTP_CREATE_SYSCALL(getresuid, cleanup, ruid, euid, suid);
 }
 
-int SETRESGID(void (cleanup)(void), GID_T rgid, GID_T egid, GID_T sgid)
+static int SETRESGID(void (cleanup)(void), GID_T rgid, GID_T egid, GID_T sgid)
 {
 	LTP_CREATE_SYSCALL(setresgid, cleanup, rgid, egid, sgid);
 }
 
-int GETRESGID(void (cleanup)(void), GID_T *rgid, GID_T *egid, GID_T *sgid)
+static int GETRESGID(void (cleanup)(void), GID_T *rgid, GID_T *egid, GID_T *sgid)
 {
 	LTP_CREATE_SYSCALL(getresgid, cleanup, rgid, egid, sgid);
 }
 
-int FCHOWN(void (cleanup)(void), unsigned int fd, UID_T owner, GID_T group)
+static int FCHOWN(void (cleanup)(void), unsigned int fd, UID_T owner, GID_T group)
 {
 	LTP_CREATE_SYSCALL(fchown, cleanup, fd, owner, group);
 }
 
-int LCHOWN(void (cleanup)(void), const char *path, UID_T owner, GID_T group)
+static int LCHOWN(void (cleanup)(void), const char *path, UID_T owner, GID_T group)
 {
 	LTP_CREATE_SYSCALL(lchown, cleanup, path, owner, group);
 }
 
-int CHOWN(void (cleanup)(void), const char *path, UID_T owner, GID_T group)
+static int CHOWN(void (cleanup)(void), const char *path, UID_T owner, GID_T group)
 {
 	LTP_CREATE_SYSCALL(chown, cleanup, path, owner, group);
 }

--- a/testcases/kernel/syscalls/utils/compat_gid.h
+++ b/testcases/kernel/syscalls/utils/compat_gid.h
@@ -23,11 +23,12 @@
 #define __COMPAT_GID_16_H__
 
 #include <asm/posix_types.h>
+
 #include "tst_common.h"
 
 #ifdef TST_USE_COMPAT16_SYSCALL
 typedef __kernel_old_gid_t GID_T;
-int GID_SIZE_CHECK(gid_t gid)
+static int GID_SIZE_CHECK(gid_t gid)
 {
 	/* See high2lowgid in linux/highuid.h
 	   Return 0 if gid is too large to store
@@ -38,7 +39,7 @@ int GID_SIZE_CHECK(gid_t gid)
 #else
 
 typedef gid_t GID_T;
-int GID_SIZE_CHECK(gid_t gid LTP_ATTRIBUTE_UNUSED)
+static int GID_SIZE_CHECK(gid_t gid LTP_ATTRIBUTE_UNUSED)
 {
 	return 1;
 }

--- a/testcases/kernel/syscalls/utils/compat_tst_16.h
+++ b/testcases/kernel/syscalls/utils/compat_tst_16.h
@@ -69,86 +69,86 @@ int setresgid(gid_t rgid, gid_t egid, gid_t sgid);
 	} \
 })
 
-int SETGROUPS(size_t gidsetsize, GID_T *list)
+static int SETGROUPS(size_t gidsetsize, GID_T *list)
 {
 	TST_CREATE_SYSCALL(setgroups, gidsetsize, list);
 }
 
-int GETGROUPS(size_t gidsetsize, GID_T *list)
+static int GETGROUPS(size_t gidsetsize, GID_T *list)
 {
 	TST_CREATE_SYSCALL(getgroups, gidsetsize, list);
 }
 
-int SETUID(UID_T uid)
+static int SETUID(UID_T uid)
 {
 	TST_CREATE_SYSCALL(setuid, uid);
 }
 
-UID_T GETUID(void)
+static UID_T GETUID(void)
 {
 	TST_CREATE_SYSCALL(getuid);
 }
 
-int SETGID(GID_T gid)
+static int SETGID(GID_T gid)
 {
 	TST_CREATE_SYSCALL(setgid, gid);
 }
 
-GID_T GETGID(void)
+static GID_T GETGID(void)
 {
 	TST_CREATE_SYSCALL(getgid);
 }
 
-UID_T GETEUID(void)
+static UID_T GETEUID(void)
 {
 	TST_CREATE_SYSCALL(geteuid);
 }
 
-GID_T GETEGID(void)
+static GID_T GETEGID(void)
 {
 	TST_CREATE_SYSCALL(getegid);
 }
 
-int SETFSUID(UID_T uid)
+static int SETFSUID(UID_T uid)
 {
 	TST_CREATE_SYSCALL(setfsuid, uid);
 }
 
-int SETFSGID(GID_T gid)
+static int SETFSGID(GID_T gid)
 {
 	TST_CREATE_SYSCALL(setfsgid, gid);
 }
 
-int SETREUID(UID_T ruid, UID_T euid)
+static int SETREUID(UID_T ruid, UID_T euid)
 {
 	TST_CREATE_SYSCALL(setreuid, ruid, euid);
 }
-int SETREGID(GID_T rgid, GID_T egid)
+static int SETREGID(GID_T rgid, GID_T egid)
 {
 	TST_CREATE_SYSCALL(setregid, rgid, egid);
 }
 
-int SETRESUID(UID_T ruid, UID_T euid, UID_T suid)
+static int SETRESUID(UID_T ruid, UID_T euid, UID_T suid)
 {
 	TST_CREATE_SYSCALL(setresuid, ruid, euid, suid);
 }
 
-int SETRESGID(GID_T rgid, GID_T egid, GID_T sgid)
+static int SETRESGID(GID_T rgid, GID_T egid, GID_T sgid)
 {
 	TST_CREATE_SYSCALL(setresgid, rgid, egid, sgid);
 }
 
-int FCHOWN(unsigned int fd, UID_T owner, GID_T group)
+static int FCHOWN(unsigned int fd, UID_T owner, GID_T group)
 {
 	TST_CREATE_SYSCALL(fchown, fd, owner, group);
 }
 
-int LCHOWN(const char *path, UID_T owner, GID_T group)
+static int LCHOWN(const char *path, UID_T owner, GID_T group)
 {
 	TST_CREATE_SYSCALL(lchown, path, owner, group);
 }
 
-int CHOWN(const char *path, UID_T owner, GID_T group)
+static int CHOWN(const char *path, UID_T owner, GID_T group)
 {
 	TST_CREATE_SYSCALL(chown, path, owner, group);
 }

--- a/testcases/kernel/syscalls/utils/compat_uid.h
+++ b/testcases/kernel/syscalls/utils/compat_uid.h
@@ -27,7 +27,7 @@
 
 #ifdef TST_USE_COMPAT16_SYSCALL
 typedef __kernel_old_uid_t UID_T;
-int UID_SIZE_CHECK(uid_t uid)
+static int UID_SIZE_CHECK(uid_t uid)
 {
 	/* See high2lowuid in linux/highuid.h
 	   Return 0 if uid is too large to store
@@ -38,7 +38,7 @@ int UID_SIZE_CHECK(uid_t uid)
 #else
 
 typedef uid_t UID_T;
-int UID_SIZE_CHECK(uid_t uid LTP_ATTRIBUTE_UNUSED)
+static int UID_SIZE_CHECK(uid_t uid LTP_ATTRIBUTE_UNUSED)
 {
 	return 1;
 }

--- a/testcases/kernel/syscalls/utils/include_j_h.h
+++ b/testcases/kernel/syscalls/utils/include_j_h.h
@@ -126,7 +126,7 @@ int setup_uid(char *uname);
 int setup_euid(char *uname, uid_t *old_uid);
 int cleanup_euid(uid_t old_uid);
 
-pid_t create_sig_proc(unsigned long usec, int sig, unsigned count);
+static pid_t create_sig_proc(unsigned long usec, int sig, unsigned count);
 
 int _setup_file(char *testdir, char *fname, char *path, int flags, mode_t mode);
 int setup_file(char *testdir, char *fname, char *path);

--- a/testcases/kernel/syscalls/utime/utime06.c
+++ b/testcases/kernel/syscalls/utime/utime06.c
@@ -55,7 +55,7 @@
 #define TEMP_FILE	"tmp_file"
 #define MNT_POINT	"mntpoint"
 
-char *TCID = "utime06";
+static char *TCID = "utime06";
 static struct passwd *ltpuser;
 static const struct utimbuf times;
 static const char *dev;
@@ -63,7 +63,7 @@ static int mount_flag;
 static void setup_nobody(void);
 static void cleanup_nobody(void);
 
-struct test_case_t {
+static struct test_case_t {
 	char *pathname;
 	int exp_errno;
 	const struct utimbuf *times;
@@ -76,7 +76,7 @@ struct test_case_t {
 	{MNT_POINT, EROFS, NULL, NULL, NULL},
 };
 
-int TST_TOTAL = ARRAY_SIZE(Test_cases);
+static int TST_TOTAL = ARRAY_SIZE(Test_cases);
 static void setup(void);
 static void utime_verify(const struct test_case_t *);
 static void cleanup(void);

--- a/testcases/kernel/syscalls/wait/wait01.c
+++ b/testcases/kernel/syscalls/wait/wait01.c
@@ -27,8 +27,8 @@
 
 #include "test.h"
 
-char *TCID = "wait01";
-int TST_TOTAL = 1;
+static char *TCID = "wait01";
+static int TST_TOTAL = 1;
 static void setup(void);
 static void wait_verify(void);
 static void cleanup(void);

--- a/testcases/kernel/syscalls/wait/wait02.c
+++ b/testcases/kernel/syscalls/wait/wait02.c
@@ -44,8 +44,8 @@
 static void setup(void);
 static void cleanup(void);
 
-char *TCID = "wait02";
-int TST_TOTAL = 1;
+static char *TCID = "wait02";
+static int TST_TOTAL = 1;
 
 static void wait_verify(void);
 

--- a/testcases/kernel/syscalls/waitid/waitid01.c
+++ b/testcases/kernel/syscalls/waitid/waitid01.c
@@ -35,11 +35,11 @@
 
 #include "test.h"
 
-char *TCID = "waitid01";
-int testno;
-int TST_TOTAL = 3;
+static char *TCID = "waitid01";
+static int testno;
+static int TST_TOTAL = 3;
 
-void setup(void)
+static void setup(void)
 {
 	TEST_PAUSE;
 }

--- a/testcases/kernel/syscalls/waitpid/waitpid03.c
+++ b/testcases/kernel/syscalls/waitpid/waitpid03.c
@@ -59,8 +59,8 @@ static void do_child(int);
 static void setup(void);
 static void cleanup(void);
 
-char *TCID = "waitpid03";
-int TST_TOTAL = 1;
+static char *TCID = "waitpid03";
+static int TST_TOTAL = 1;
 
 #define	MAXUPRC	25
 

--- a/testcases/kernel/syscalls/waitpid/waitpid_common.h
+++ b/testcases/kernel/syscalls/waitpid/waitpid_common.h
@@ -73,7 +73,7 @@ static int waitpid_errno_check(int err, int exp_err)
 	return 0;
 }
 
-int waitpid_ret_test(pid_t wp_pid, int *wp_status, int wp_opts,
+static int waitpid_ret_test(pid_t wp_pid, int *wp_status, int wp_opts,
 		     pid_t wp_ret, int wp_errno)
 {
 	pid_t ret;

--- a/testcases/kernel/syscalls/writev/writev01.c
+++ b/testcases/kernel/syscalls/writev/writev01.c
@@ -41,7 +41,7 @@ struct iovec iovec_zero_null[] = {
 	{ NULL, 0 }
 };
 
-struct testcase_t {
+static struct testcase_t {
 	const char *desc;
 	int *pfd;
 	struct iovec (*piovec)[];
@@ -97,7 +97,7 @@ struct testcase_t {
 	},
 };
 
-void setup(void)
+static void setup(void)
 {
 	sigset_t block_mask;
 


### PR DESCRIPTION
In the LTP kernel test cases, there are many global functions and fields are defined with the same name. In order to compile these cases at the same time, these functions need to be defined as static to avoid "multiple definition erorr"